### PR TITLE
Add Spain VeriFactu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# VS Code
+.vscode
+
+# Copilot instructions files
+.github/copilot-test-instructions.md
+.github/copilot-instructions.md

--- a/examples/country-specific-examples/spain/Verifactu/PUF_Spain_VeriFactu_CreditNote_Substitutive.xml
+++ b/examples/country-specific-examples/spain/Verifactu/PUF_Spain_VeriFactu_CreditNote_Substitutive.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Example: Spain VeriFactu Credit Note - Substitutive Method (R1)
+    
+    This example demonstrates:
+    - Credit note type with R1 code
+    - Substitutive correction method "S"
+    - Referenced invoice amounts (TaxableAmount, TaxAmount, EquivalenceSurchargeAmount)
+    - Full credit note with new values
+-->
+<CreditNote xmlns="urn:pagero:PageroUniversalFormat:CreditNote:1.0" xmlns:cac="urn:pagero:CommonAggregateComponents:1.0" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:puf="urn:pagero:ExtensionComponent:1.0">
+    <!-- Invoice series extension -->
+    <ext:UBLExtensions>
+        <ext:UBLExtension>
+            <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:InvoiceSeries</ext:ExtensionURI>
+            <ext:ExtensionContent>
+                <puf:PageroExtension>
+                    <puf:InvoiceSeries>
+                        <cbc:ID>2025-CN</cbc:ID>
+                    </puf:InvoiceSeries>
+                </puf:PageroExtension>
+            </ext:ExtensionContent>
+        </ext:UBLExtension>
+    </ext:UBLExtensions>
+    <cbc:CustomizationID>urn:pagero.com:puf:billing:2.0</cbc:CustomizationID>
+    <cbc:ProfileID>urn:pagero.com:puf:billing:1.0</cbc:ProfileID>
+    <cbc:ID>CN-2025-001</cbc:ID>
+    <cbc:IssueDate>2025-01-20</cbc:IssueDate>
+    <cbc:CreditNoteTypeCode name="R1">381</cbc:CreditNoteTypeCode>
+    <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+
+    <!-- Billing Reference with substitutive method amounts -->
+    <cac:BillingReference>
+        <cac:InvoiceDocumentReference>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:BillingReferenceExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:BillingReferenceExtension>
+                                <puf:InvoiceSeries>
+                                    <cbc:ID>2025-A</cbc:ID>
+                                </puf:InvoiceSeries>
+                                <cbc:Note>Anulación completa y reemisión</cbc:Note>
+                                <puf:Code>S</puf:Code>
+                                <cbc:TaxableAmount currencyID="EUR">1000.00</cbc:TaxableAmount>
+                                <cbc:TaxAmount currencyID="EUR">210.00</cbc:TaxAmount>
+                                <puf:EquivalenceSurchargeAmount currencyID="EUR">52.00</puf:EquivalenceSurchargeAmount>
+                            </puf:BillingReferenceExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <cbc:ID>INV-2025-005</cbc:ID>
+            <cbc:IssueDate>2025-01-10</cbc:IssueDate>
+        </cac:InvoiceDocumentReference>
+    </cac:BillingReference>
+
+    <!-- Seller Party -->
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Comercio Minorista S.L.</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Calle Tienda 25</cbc:StreetName>
+                <cbc:CityName>Sevilla</cbc:CityName>
+                <cbc:PostalZone>41001</cbc:PostalZone>
+                <cbc:CountrySubentity>Sevilla</cbc:CountrySubentity>
+                <cac:Country>
+                    <cbc:IdentificationCode>ES</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>ESB22334455</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Comercio Minorista S.L.</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+
+    <!-- Buyer Party -->
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Cliente Final S.L.</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Avenida Comercial 100</cbc:StreetName>
+                <cbc:CityName>Sevilla</cbc:CityName>
+                <cbc:PostalZone>41002</cbc:PostalZone>
+                <cbc:CountrySubentity>Sevilla</cbc:CountrySubentity>
+                <cac:Country>
+                    <cbc:IdentificationCode>ES</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>ESB99887766</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Cliente Final S.L.</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+
+    <!-- Tax Total with Equivalence Surcharge -->
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">262.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:TaxSubtotalExtension>
+                                <puf:SpecialRegimeKey>18</puf:SpecialRegimeKey>
+                                <puf:EquivalenceSurcharge>
+                                    <cbc:Percent>5.2</cbc:Percent>
+                                    <puf:Amount currencyID="EUR">52.00</puf:Amount>
+                                </puf:EquivalenceSurcharge>
+                            </puf:TaxSubtotalExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <cbc:TaxableAmount currencyID="EUR">1000.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="EUR">210.00</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>21.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+
+    <!-- Legal Monetary Total -->
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">1000.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">1000.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">1262.00</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">1262.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+
+    <!-- Credit Note Line -->
+    <cac:CreditNoteLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:CreditedQuantity unitCode="PCE">10</cbc:CreditedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">1000.00</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Description>Productos textiles</cbc:Description>
+            <cbc:Name>Ropa variada</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>21.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+        </cac:Price>
+    </cac:CreditNoteLine>
+
+</CreditNote>

--- a/examples/country-specific-examples/spain/Verifactu/PUF_Spain_VeriFactu_MultipleTaxRates.xml
+++ b/examples/country-specific-examples/spain/Verifactu/PUF_Spain_VeriFactu_MultipleTaxRates.xml
@@ -1,0 +1,252 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Example: Spain VeriFactu Invoice with Multiple Tax Rates and Exemptions
+    
+    This example demonstrates:
+    - Multiple tax rates (21%, 10%)
+    - Special regime keys for different scenarios
+    - Tax exemption code E2 for export operations
+    - Export operations (special regime 02)
+-->
+<Invoice xmlns="urn:pagero:PageroUniversalFormat:Invoice:1.0"
+         xmlns:cac="urn:pagero:CommonAggregateComponents:1.0"
+         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+         xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+         xmlns:puf="urn:pagero:ExtensionComponent:1.0">
+    
+    <!-- Invoice series extension -->
+    <ext:UBLExtensions>
+        <ext:UBLExtension>
+            <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:InvoiceSeries</ext:ExtensionURI>
+            <ext:ExtensionContent>
+                <puf:PageroExtension>
+                    <puf:InvoiceSeries>
+                        <cbc:ID>2025-M</cbc:ID>
+                    </puf:InvoiceSeries>
+                </puf:PageroExtension>
+            </ext:ExtensionContent>
+        </ext:UBLExtension>
+    </ext:UBLExtensions>
+    
+    <cbc:CustomizationID>urn:pagero.com:puf:billing:2.0</cbc:CustomizationID>
+    <cbc:ProfileID>urn:pagero.com:puf:billing:1.0</cbc:ProfileID>
+    <cbc:ID>MIX-2025-001</cbc:ID>
+    <cbc:IssueDate>2025-01-30</cbc:IssueDate>
+    <cbc:DueDate>2025-03-01</cbc:DueDate>
+    <cbc:InvoiceTypeCode name="F1">380</cbc:InvoiceTypeCode>
+    <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+    
+    <!-- Seller Party -->
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Exportadora Internacional S.L.</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Calle Exportación 88</cbc:StreetName>
+                <cbc:CityName>Bilbao</cbc:CityName>
+                <cbc:PostalZone>48001</cbc:PostalZone>
+                <cbc:CountrySubentity>Vizcaya</cbc:CountrySubentity>
+                <cac:Country>
+                    <cbc:IdentificationCode>ES</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>ESB99887755</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Exportadora Internacional S.L.</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    
+    <!-- Buyer Party -->
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Cliente Mixto S.A.</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Avenida Industria 300</cbc:StreetName>
+                <cbc:CityName>Bilbao</cbc:CityName>
+                <cbc:PostalZone>48003</cbc:PostalZone>
+                <cbc:CountrySubentity>Vizcaya</cbc:CountrySubentity>
+                <cac:Country>
+                    <cbc:IdentificationCode>ES</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>ESB11223399</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Cliente Mixto S.A.</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    
+    <!-- Payment Terms -->
+    <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+            <cbc:ID>ES3521000813610123456789</cbc:ID>
+        </cac:PayeeFinancialAccount>
+    </cac:PaymentMeans>
+    
+    <!-- Tax Total with multiple rates and exemptions -->
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">310.00</cbc:TaxAmount>
+        
+        <!-- Standard rate 21% - General regime -->
+        <cac:TaxSubtotal>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:TaxSubtotalExtension>
+                                <puf:SpecialRegimeKey>01</puf:SpecialRegimeKey>
+                            </puf:TaxSubtotalExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <cbc:TaxableAmount currencyID="EUR">1000.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="EUR">210.00</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>21.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        
+        <!-- Reduced rate 10% - General regime -->
+        <cac:TaxSubtotal>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:TaxSubtotalExtension>
+                                <puf:SpecialRegimeKey>01</puf:SpecialRegimeKey>
+                            </puf:TaxSubtotalExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <cbc:TaxableAmount currencyID="EUR">1000.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="EUR">100.00</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>10.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        
+        <!-- Exempt - Export operations -->
+        <cac:TaxSubtotal>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:TaxSubtotalExtension>
+                                <puf:SpecialRegimeKey>02</puf:SpecialRegimeKey>
+                            </puf:TaxSubtotalExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <cbc:TaxableAmount currencyID="EUR">5000.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID>E</cbc:ID>
+                <cbc:Percent>0</cbc:Percent>
+                <cbc:TaxExemptionReasonCode>E2</cbc:TaxExemptionReasonCode>
+                <cbc:TaxExemptionReason>Exenta por el artículo 21 - Exportación</cbc:TaxExemptionReason>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    
+    <!-- Legal Monetary Total -->
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">7000.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">7000.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">7310.00</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">7310.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    
+    <!-- Invoice Lines -->
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="PCE">20</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">1000.00</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Description>Equipos electrónicos</cbc:Description>
+            <cbc:Name>Ordenadores portátiles</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>21.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="EUR">50.00</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+    
+    <cac:InvoiceLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="PCE">100</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">1000.00</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Description>Productos alimenticios</cbc:Description>
+            <cbc:Name>Alimentos básicos</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>10.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="EUR">10.00</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+    
+    <cac:InvoiceLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="PCE">10</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">5000.00</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Description>Maquinaria para exportación</cbc:Description>
+            <cbc:Name>Equipos industriales</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>E</cbc:ID>
+                <cbc:Percent>0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="EUR">500.00</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+    
+</Invoice>

--- a/examples/country-specific-examples/spain/Verifactu/PUF_Spain_VeriFactu_OutOfScope.xml
+++ b/examples/country-specific-examples/spain/Verifactu/PUF_Spain_VeriFactu_OutOfScope.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Example: Spain VeriFactu Invoice - Out of Scope Transactions
+    
+    This example demonstrates:
+    - Not subject to VAT transactions (outside scope)
+    - Tax exemption code N2 (location rules)
+    - Special regime key for out of scope operations
+    - Services provided outside Spain
+-->
+<Invoice xmlns="urn:pagero:PageroUniversalFormat:Invoice:1.0"
+         xmlns:cac="urn:pagero:CommonAggregateComponents:1.0"
+         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+         xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+         xmlns:puf="urn:pagero:ExtensionComponent:1.0">
+    
+    <!-- Invoice series extension -->
+    <ext:UBLExtensions>
+        <ext:UBLExtension>
+            <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:InvoiceSeries</ext:ExtensionURI>
+            <ext:ExtensionContent>
+                <puf:PageroExtension>
+                    <puf:InvoiceSeries>
+                        <cbc:ID>2025-O</cbc:ID>
+                    </puf:InvoiceSeries>
+                </puf:PageroExtension>
+            </ext:ExtensionContent>
+        </ext:UBLExtension>
+    </ext:UBLExtensions>
+    
+    <cbc:CustomizationID>urn:pagero.com:puf:billing:2.0</cbc:CustomizationID>
+    <cbc:ProfileID>urn:pagero.com:puf:billing:1.0</cbc:ProfileID>
+    <cbc:ID>OOS-2025-001</cbc:ID>
+    <cbc:IssueDate>2025-02-01</cbc:IssueDate>
+    <cbc:DueDate>2025-03-03</cbc:DueDate>
+    <cbc:InvoiceTypeCode name="F1">380</cbc:InvoiceTypeCode>
+    <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+    
+    <!-- Seller Party -->
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Consultora Internacional S.L.</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Calle Servicios 77</cbc:StreetName>
+                <cbc:CityName>Madrid</cbc:CityName>
+                <cbc:PostalZone>28002</cbc:PostalZone>
+                <cbc:CountrySubentity>Madrid</cbc:CountrySubentity>
+                <cac:Country>
+                    <cbc:IdentificationCode>ES</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>ESB66778899</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Consultora Internacional S.L.</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    
+    <!-- Buyer Party - Foreign company -->
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Foreign Company Ltd.</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>123 Business Street</cbc:StreetName>
+                <cbc:CityName>London</cbc:CityName>
+                <cbc:PostalZone>SW1A 1AA</cbc:PostalZone>
+                <cbc:CountrySubentity>England</cbc:CountrySubentity>
+                <cac:Country>
+                    <cbc:IdentificationCode>GB</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>GB123456789</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Foreign Company Ltd.</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    
+    <!-- Payment Terms -->
+    <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+            <cbc:ID>ES4521000813610987654321</cbc:ID>
+        </cac:PayeeFinancialAccount>
+    </cac:PaymentMeans>
+    
+    <!-- Tax Total - Not subject to VAT -->
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+        
+        <!-- Not subject - Location rules (Article 7) -->
+        <cac:TaxSubtotal>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:TaxSubtotalExtension>
+                                <puf:SpecialRegimeKey>01</puf:SpecialRegimeKey>
+                            </puf:TaxSubtotalExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <cbc:TaxableAmount currencyID="EUR">5000.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID>O</cbc:ID>
+                <cbc:Percent>0</cbc:Percent>
+                <cbc:TaxExemptionReasonCode>N2</cbc:TaxExemptionReasonCode>
+                <cbc:TaxExemptionReason>No sujeta por reglas de localización - Artículo 7 LIVA</cbc:TaxExemptionReason>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    
+    <!-- Legal Monetary Total -->
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">5000.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">5000.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">5000.00</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">5000.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    
+    <!-- Invoice Lines -->
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="HUR">200</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">5000.00</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Description>Servicios de consultoría prestados en el Reino Unido</cbc:Description>
+            <cbc:Name>Consultoría técnica internacional</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>O</cbc:ID>
+                <cbc:Percent>0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="EUR">25.00</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+    
+</Invoice>

--- a/examples/country-specific-examples/spain/Verifactu/PUF_Spain_VeriFactu_Rectificative_Differences.xml
+++ b/examples/country-specific-examples/spain/Verifactu/PUF_Spain_VeriFactu_Rectificative_Differences.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Example: Spain VeriFactu Rectificative Invoice - Correction by Differences (R1)
+    
+    This example demonstrates:
+    - Rectificative invoice type (R1) - Error fundado en derecho
+    - Correction method "I" (differences)
+    - BillingReference with correction information
+    - Referenced invoice series and correction code
+-->
+<Invoice xmlns="urn:pagero:PageroUniversalFormat:Invoice:1.0"
+         xmlns:cac="urn:pagero:CommonAggregateComponents:1.0"
+         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+         xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+         xmlns:puf="urn:pagero:ExtensionComponent:1.0">
+    
+    <!-- Invoice series extension -->
+    <ext:UBLExtensions>
+        <ext:UBLExtension>
+            <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:InvoiceSeries</ext:ExtensionURI>
+            <ext:ExtensionContent>
+                <puf:PageroExtension>
+                    <puf:InvoiceSeries>
+                        <cbc:ID>2025-R</cbc:ID>
+                    </puf:InvoiceSeries>
+                </puf:PageroExtension>
+            </ext:ExtensionContent>
+        </ext:UBLExtension>
+    </ext:UBLExtensions>
+    
+    <cbc:CustomizationID>urn:pagero.com:puf:billing:2.0</cbc:CustomizationID>
+    <cbc:ProfileID>urn:pagero.com:puf:billing:1.0</cbc:ProfileID>
+    <cbc:ID>RECT-2025-001</cbc:ID>
+    <cbc:IssueDate>2025-01-20</cbc:IssueDate>
+    <cbc:InvoiceTypeCode name="R1">384</cbc:InvoiceTypeCode>
+    <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+    
+    <!-- Billing Reference with correction information -->
+    <cac:BillingReference>
+        <cac:InvoiceDocumentReference>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:BillingReferenceExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:BillingReferenceExtension>
+                                <puf:InvoiceSeries>
+                                    <cbc:ID>2025-A</cbc:ID>
+                                </puf:InvoiceSeries>
+                                <cbc:Note>Error en la tasa de IVA aplicada</cbc:Note>
+                                <puf:Code>I</puf:Code>
+                            </puf:BillingReferenceExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <cbc:ID>INV-2025-001</cbc:ID>
+            <cbc:IssueDate>2025-01-15</cbc:IssueDate>
+        </cac:InvoiceDocumentReference>
+    </cac:BillingReference>
+    
+    <!-- Seller Party -->
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Empresa Española S.L.</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Calle Mayor 123</cbc:StreetName>
+                <cbc:CityName>Madrid</cbc:CityName>
+                <cbc:PostalZone>28001</cbc:PostalZone>
+                <cbc:CountrySubentity>Madrid</cbc:CountrySubentity>
+                <cac:Country>
+                    <cbc:IdentificationCode>ES</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>ESB12345678</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Empresa Española S.L.</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    
+    <!-- Buyer Party -->
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Cliente Empresa S.A.</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Avenida Principal 456</cbc:StreetName>
+                <cbc:CityName>Barcelona</cbc:CityName>
+                <cbc:PostalZone>08001</cbc:PostalZone>
+                <cbc:CountrySubentity>Barcelona</cbc:CountrySubentity>
+                <cac:Country>
+                    <cbc:IdentificationCode>ES</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>ESB87654321</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Cliente Empresa S.A.</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    
+    <!-- Tax Total - Correction difference -->
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">-10.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:TaxSubtotalExtension>
+                                <puf:SpecialRegimeKey>01</puf:SpecialRegimeKey>
+                            </puf:TaxSubtotalExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <cbc:TaxableAmount currencyID="EUR">0.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="EUR">-10.00</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>21.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    
+    <!-- Legal Monetary Total -->
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">0.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">0.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">-10.00</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">-10.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    
+    <!-- Invoice Line - Correction -->
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="PCE">0</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">0.00</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Description>Corrección de tasa de IVA</cbc:Description>
+            <cbc:Name>Ajuste fiscal</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>21.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="EUR">0.00</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+    
+</Invoice>

--- a/examples/country-specific-examples/spain/Verifactu/PUF_Spain_VeriFactu_Simplified_Invoice.xml
+++ b/examples/country-specific-examples/spain/Verifactu/PUF_Spain_VeriFactu_Simplified_Invoice.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Example: Spain VeriFactu Simplified Invoice (F2)
+    
+    This example demonstrates:
+    - Simplified invoice type (F2)
+    - Simplified invoice indicator (RestrictedInformation)
+    - No buyer VAT identification required
+    - Alternative buyer identification (passport)
+    - IVA tax with special regime key
+-->
+<Invoice xmlns="urn:pagero:PageroUniversalFormat:Invoice:1.0"
+         xmlns:cac="urn:pagero:CommonAggregateComponents:1.0"
+         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+         xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+         xmlns:puf="urn:pagero:ExtensionComponent:1.0">
+    
+    <!-- Invoice series and simplified invoice indicator (Article 7.2/7.3) -->
+    <ext:UBLExtensions>
+        <ext:UBLExtension>
+            <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:InvoiceSeries</ext:ExtensionURI>
+            <ext:ExtensionContent>
+                <puf:PageroExtension>
+                    <puf:InvoiceSeries>
+                        <cbc:ID>2025-S</cbc:ID>
+                    </puf:InvoiceSeries>
+                </puf:PageroExtension>
+            </ext:ExtensionContent>
+        </ext:UBLExtension>
+        <ext:UBLExtension>
+            <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:Simplified</ext:ExtensionURI>
+            <ext:ExtensionContent>
+                <puf:PageroExtension>
+                    <puf:Simplified>true</puf:Simplified>
+                </puf:PageroExtension>
+            </ext:ExtensionContent>
+        </ext:UBLExtension>
+    </ext:UBLExtensions>
+    
+    <cbc:CustomizationID>urn:pagero.com:puf:billing:2.0</cbc:CustomizationID>
+    <cbc:ProfileID>urn:pagero.com:puf:billing:1.0</cbc:ProfileID>
+    <cbc:ID>SIMP-2025-001</cbc:ID>
+    <cbc:IssueDate>2025-01-15</cbc:IssueDate>
+    <cbc:InvoiceTypeCode name="F2">380</cbc:InvoiceTypeCode>
+    <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+    
+    <!-- Seller Party -->
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Tienda Minorista S.L.</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Calle Comercio 50</cbc:StreetName>
+                <cbc:CityName>Valencia</cbc:CityName>
+                <cbc:PostalZone>46001</cbc:PostalZone>
+                <cbc:CountrySubentity>Valencia</cbc:CountrySubentity>
+                <cac:Country>
+                    <cbc:IdentificationCode>ES</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>ESB11223344</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Tienda Minorista S.L.</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    
+    <!-- Buyer Party - Alternative identification (no VAT) -->
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="ES:PASSPORT">AB123456</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>Cliente Individual</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Calle Secundaria 789</cbc:StreetName>
+                <cbc:CityName>Valencia</cbc:CityName>
+                <cbc:PostalZone>46001</cbc:PostalZone>
+                <cbc:CountrySubentity>Valencia</cbc:CountrySubentity>
+                <cac:Country>
+                    <cbc:IdentificationCode>ES</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Cliente Individual</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    
+    <!-- Payment Terms -->
+    <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>10</cbc:PaymentMeansCode>
+    </cac:PaymentMeans>
+    
+    <!-- Tax Total -->
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">42.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:TaxSubtotalExtension>
+                                <puf:SpecialRegimeKey>01</puf:SpecialRegimeKey>
+                            </puf:TaxSubtotalExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <cbc:TaxableAmount currencyID="EUR">200.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="EUR">42.00</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>21.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    
+    <!-- Legal Monetary Total -->
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">200.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">200.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">242.00</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">242.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    
+    <!-- Invoice Line -->
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="PCE">2</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">200.00</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Description>Producto electrónico</cbc:Description>
+            <cbc:Name>Smartphone</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>21.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+    
+</Invoice>

--- a/examples/country-specific-examples/spain/Verifactu/PUF_Spain_VeriFactu_Standard_Invoice.xml
+++ b/examples/country-specific-examples/spain/Verifactu/PUF_Spain_VeriFactu_Standard_Invoice.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Example: Spain VeriFactu Standard Invoice (F1)
+    
+    This example demonstrates:
+    - Standard invoice type (F1) with invoice series
+    - Spanish NIF for seller and buyer
+    - IVA (VAT) tax with special regime key (mandatory)
+    - General regime (SpecialRegimeKey 01)
+-->
+<Invoice xmlns="urn:pagero:PageroUniversalFormat:Invoice:1.0"
+         xmlns:cac="urn:pagero:CommonAggregateComponents:1.0"
+         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+         xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+         xmlns:puf="urn:pagero:ExtensionComponent:1.0">
+    
+    <!-- Invoice series extension (mandatory for VeriFactu) -->
+    <ext:UBLExtensions>
+        <ext:UBLExtension>
+            <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:InvoiceSeries</ext:ExtensionURI>
+            <ext:ExtensionContent>
+                <puf:PageroExtension>
+                    <puf:InvoiceSeries>
+                        <cbc:ID>2025-A</cbc:ID>
+                    </puf:InvoiceSeries>
+                </puf:PageroExtension>
+            </ext:ExtensionContent>
+        </ext:UBLExtension>
+    </ext:UBLExtensions>
+    
+    <cbc:CustomizationID>urn:pagero.com:puf:billing:2.0</cbc:CustomizationID>
+    <cbc:ProfileID>urn:pagero.com:puf:billing:1.0</cbc:ProfileID>
+    <cbc:ID>INV-2025-001</cbc:ID>
+    <cbc:IssueDate>2025-01-15</cbc:IssueDate>
+    <cbc:DueDate>2025-02-15</cbc:DueDate>
+    <cbc:InvoiceTypeCode name="F1">380</cbc:InvoiceTypeCode>
+    <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+    
+    <!-- Seller Party -->
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Empresa Española S.L.</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Calle Mayor 123</cbc:StreetName>
+                <cbc:CityName>Madrid</cbc:CityName>
+                <cbc:PostalZone>28001</cbc:PostalZone>
+                <cbc:CountrySubentity>Madrid</cbc:CountrySubentity>
+                <cac:Country>
+                    <cbc:IdentificationCode>ES</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>ESB12345678</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Empresa Española S.L.</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    
+    <!-- Buyer Party -->
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Cliente Empresa S.A.</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Avenida Principal 456</cbc:StreetName>
+                <cbc:CityName>Barcelona</cbc:CityName>
+                <cbc:PostalZone>08001</cbc:PostalZone>
+                <cbc:CountrySubentity>Barcelona</cbc:CountrySubentity>
+                <cac:Country>
+                    <cbc:IdentificationCode>ES</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>ESB87654321</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Cliente Empresa S.A.</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    
+    <!-- Payment Terms -->
+    <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+            <cbc:ID>ES9121000418450200051332</cbc:ID>
+        </cac:PayeeFinancialAccount>
+    </cac:PaymentMeans>
+    
+    <!-- Tax Total with Special Regime Key (mandatory for VeriFactu) -->
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">210.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:TaxSubtotalExtension>
+                                <puf:SpecialRegimeKey>01</puf:SpecialRegimeKey>
+                            </puf:TaxSubtotalExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <cbc:TaxableAmount currencyID="EUR">1000.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="EUR">210.00</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>21.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    
+    <!-- Legal Monetary Total -->
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">1000.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">1000.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">1210.00</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">1210.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    
+    <!-- Invoice Line -->
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="PCE">10</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">1000.00</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Description>Servicio de consultoría</cbc:Description>
+            <cbc:Name>Consultoría IT</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>21.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+    
+</Invoice>

--- a/examples/country-specific-examples/spain/Verifactu/README.md
+++ b/examples/country-specific-examples/spain/Verifactu/README.md
@@ -1,0 +1,284 @@
+# Spain VeriFactu Examples
+
+This directory contains example PUF invoice files demonstrating Spain's VeriFactu e-invoicing system implementation.
+
+## Overview
+
+VeriFactu is a voluntary e-invoicing framework regulated by the Spanish Tax Agency (AEAT). These examples demonstrate key VeriFactu requirements including:
+
+- Invoice series (mandatory)
+- Invoice type codes with Spanish identifiers (F1-F3, R1-R5)
+- Special regime keys (ClaveRegimen) - mandatory for all tax breakdowns
+- Tax exemption codes
+- Equivalence surcharge (Recargo de Equivalencia)
+- Correction methods (differences and substitutive)
+
+## Example Files
+
+### 1. PUF_Spain_VeriFactu_Standard_Invoice.xml
+
+**Standard Invoice (F1)**
+
+Demonstrates:
+
+- Invoice type F1 (Standard invoice per RD 1619/2012)
+- Mandatory invoice series extension (`InvoiceSeries`)
+- Spanish NIF for seller and buyer parties
+- IVA (VAT) at 21% standard rate
+- Special regime key `01` (General regime)
+
+**Key Features:**
+
+- Document type: 380 with name="F1"
+- Single tax breakdown with mandatory special regime key
+- Complete party information with Spanish tax identifiers
+
+---
+
+### 2. PUF_Spain_VeriFactu_Simplified_Invoice.xml
+
+**Simplified Invoice (F2)**
+
+Demonstrates:
+
+- Invoice type F2 (Factura Simplificada)
+- Simplified invoice qualifier (`puf:Simplified` extension) for Article 7.2/7.3 applicability
+- Alternative buyer identification (passport) when VAT number not available
+- Simplified invoice characteristics per Article 6.1.d) RD 1619/2012
+
+**Key Features:**
+
+- Document type: 380 with name="F2"
+- `puf:Simplified` boolean extension (`true` indicates Article 7.2/7.3 simplified case)
+- Buyer identification using scheme ES:PASSPORT
+
+---
+
+### 3. PUF_Spain_VeriFactu_Rectificative_Differences.xml
+
+**Rectificative Invoice - Correction by Differences (R1)**
+
+Demonstrates:
+
+- Rectificative invoice type R1 (Error fundado en derecho)
+- Correction method "I" (corrección por diferencias)
+- BillingReference with correction information
+- Referenced invoice series and issue date
+
+**Key Features:**
+
+- Document type: 384 with name="R1"
+- BillingReferenceExtension with Code="I"
+- Referenced invoice series in extension
+- Negative amounts for corrections
+
+---
+
+### 4. PUF_Spain_VeriFactu_CreditNote_Substitutive.xml
+
+**Credit Note - Substitutive Method (R1)**
+
+Demonstrates:
+
+- Credit note with rectificative type R1
+- Substitutive correction method "S" (método sustitutivo)
+- Referenced invoice amounts (mandatory for substitutive method):
+  - TaxableAmount
+  - TaxAmount
+  - EquivalenceSurchargeAmount
+- Complete credit note with equivalence surcharge
+
+**Key Features:**
+
+- Document type: 381 with name="R1"
+- BillingReferenceExtension with Code="S"
+- All referenced amounts included in extension
+- Special regime key `18` (Equivalence surcharge)
+- EquivalenceSurcharge extension with rate and amount
+
+---
+
+### 5. PUF_Spain_VeriFactu_MultipleTaxRates.xml
+
+#### Invoice with Multiple Tax Rates and Exemptions
+
+Demonstrates:
+
+- Multiple tax rates (21% standard, 10% reduced)
+- Export operations with special regime key `02`
+- Tax exemption code E2 (Exempt per Article 21)
+- Different special regime keys for different scenarios
+
+**Key Features:**
+
+- Three tax subtotals with different treatments:
+  1. Standard rate 21% - General regime (01)
+  2. Reduced rate 10% - General regime (01)
+  3. Exempt (E) - Export operations (02) with exemption code E2
+- TaxExemptionReasonCode and TaxExemptionReason for exempt cases
+
+---
+
+### 6. PUF_Spain_VeriFactu_OutOfScope.xml
+
+#### Invoice with Not Subject to VAT Transactions
+
+Demonstrates:
+
+- Not subject to VAT transactions (category O)
+- Tax exemption code N2 (Location rules - Article 7 LIVA)
+- Services provided outside Spain
+- Special regime key for out of scope operations
+- Separate invoice from taxable transactions (best practice)
+
+**Key Features:**
+
+- Tax category: O (Out of scope)
+- TaxExemptionReasonCode: N2 (Article 7 location rules)
+- Zero tax amount with valid tax base
+- Foreign buyer identification
+- Service delivery outside Spanish territory
+
+---
+
+## Common VeriFactu Requirements
+
+### Mandatory Elements
+
+1. **Invoice Series** (`InvoiceSeries` extension)
+   - Required for all VeriFactu invoices
+   - URI: `urn:pagero:ExtensionComponent:1.0:PageroExtension:InvoiceSeries`
+
+2. **Invoice Type Code with @name attribute**
+   - Standard invoices: F1, F2, F3
+   - Rectifications: R1, R2, R3, R4, R5
+   - Example: `<cbc:InvoiceTypeCode name="F1">380</cbc:InvoiceTypeCode>`
+
+3. **Special Regime Key** (ClaveRegimen)
+   - Mandatory for ALL tax breakdowns
+   - URI: `urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension`
+   - Common codes:
+     - `01` - General regime (Régimen general)
+     - `02` - Export operations (Exportación)
+     - `06` - VAT group advanced level
+     - `18` - Equivalence surcharge
+
+4. **Spanish Tax Identification**
+   - Seller NIF: Mandatory
+   - Buyer NIF: Conditionally mandatory
+   - Format: ES + 9 characters (e.g., ESB12345678)
+
+### Optional Elements
+
+1. **Simplified Invoice Indicator**
+   - RestrictedInformation extension
+   - Key: "SimplifiedInvoice"
+   - Value: "S" (yes) or "N" (no)
+
+2. **Equivalence Surcharge**
+   - For retail traders subject to Recargo de Equivalencia
+   - Requires special regime key `18`
+   - Includes both percentage and amount
+
+3. **Tax Base at Cost**
+   - For special group regimes
+   - Used with special regime key `06`
+
+## Tax Types Supported
+
+- **VAT** (IVA): Standard Spanish VAT - Use TaxScheme/ID = "VAT"
+- **IGIC**: Canary Islands special tax - Use TaxScheme/ID = "IGIC"
+- **IPSI**: Ceuta and Melilla special tax - Use TaxScheme/ID = "IPSI"
+
+## Special Regime Keys (ClaveRegimen)
+
+See [PUF-022-SPECIALREGIMEKEY](https://pagero.github.io/puf-code-lists/#_puf_022_specialregimekey) for the complete list.
+
+Common codes:
+
+- `01` - General regime (IVA)
+- `02` - Export operations
+- `03` - Operations subject to IPSI (Ceuta/Melilla)
+- `04` - Operations subject to IGIC (Canary Islands)
+- `05` - Travel agencies
+- `06` - VAT group advanced level
+- `07` - Cash basis scheme
+- `18` - Equivalence surcharge
+
+## Tax Exemption Codes
+
+See [PUF-013-TAXEXEMPTIONCODE](https://pagero.github.io/puf-code-lists/#_tax_exemption_codes_in_spain_verifactu) for Spain-specific codes.
+
+**Exempt (E):**
+
+- `E2` - Exempt pursuant to Article 21
+- `E5` - Exempt pursuant to Article 22
+
+**Not Subject (O):**
+
+- `N1` - Not subject per Article 7 (Location of operation)
+- `N2` - Not subject due to location rules
+
+## Correction Methods
+
+### Method I - Correction by Differences (corrección por diferencias)
+
+- Shows only the difference amounts
+- Use `puf:Code = "I"` in BillingReferenceExtension
+
+### Method S - Substitutive (método sustitutivo)
+
+- Complete cancellation and re-issue
+- Use `puf:Code = "S"` in BillingReferenceExtension
+- **Mandatory fields in BillingReferenceExtension:**
+  - `cbc:TaxableAmount` - Original invoice tax base
+  - `cbc:TaxAmount` - Original invoice tax amount
+  - `puf:EquivalenceSurchargeAmount` - If applicable
+
+## Extensions Used
+
+### Document Level
+
+1. **InvoiceSeries**
+   - Location: Invoice/ext:UBLExtensions
+   - URI: `urn:pagero:ExtensionComponent:1.0:PageroExtension:InvoiceSeries`
+
+2. **RestrictedInformation**
+   - Location: Invoice/ext:UBLExtensions
+   - URI: `urn:pagero:ExtensionComponent:1.0:PageroExtension:RestrictedInformation`
+
+3. **BillingReferenceExtension**
+   - Location: BillingReference/InvoiceDocumentReference/ext:UBLExtensions
+   - URI: `urn:pagero:ExtensionComponent:1.0:PageroExtension:BillingReferenceExtension`
+
+### Tax Level
+
+1. **TaxSubtotalExtension**
+   - Location: TaxTotal/TaxSubtotal/ext:UBLExtensions
+   - URI: `urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension`
+   - Contains: SpecialRegimeKey, EquivalenceSurcharge, TaxBaseAtCost
+
+## References
+
+- [PUF Billing Specification](https://pagero.github.io/puf-billing/)
+- [Spain VeriFactu Documentation](https://pagero.github.io/puf-billing/#_spain_verifactu)
+- [PUF Code Lists](https://pagero.github.io/puf-code-lists/)
+- [PUF-003-INVOICETYPECODE (Spain)](https://pagero.github.io/puf-code-lists/#_invoice_type_codes_for_spain_verifactu)
+- [PUF-022-SPECIALREGIMEKEY](https://pagero.github.io/puf-code-lists/#_puf_022_specialregimekey)
+- [PUF-013-TAXEXEMPTIONCODE (Spain)](https://pagero.github.io/puf-code-lists/#_tax_exemption_codes_in_spain_verifactu)
+
+## Validation
+
+All examples should validate against:
+
+- PUF XSD schemas (`xml-schemas/maindoc/UBL-Invoice-2.1.xsd`)
+- PUF Schematron rules (`validation-artefacts/PUF-UBL.sch`)
+- Spain VeriFactu business rules
+
+## Notes
+
+- **Special Regime Key is ALWAYS mandatory** for VeriFactu - every tax subtotal must include it
+- Invoice series is mandatory for all VeriFactu invoices
+- Equivalence surcharge applies only to certain retail traders
+- Substitutive method requires all original invoice amounts in the billing reference
+- Tax exemption codes are mandatory when using tax categories E (Exempt) or O (Not subject)

--- a/index.html
+++ b/index.html
@@ -632,23 +632,24 @@ table.CodeRay td.code{padding:0 0 0 .75em}
 <li><a href="#_returnable_restricted_information">4.1.2. Returnable Restricted Information</a></li>
 <li><a href="#_restrictedinformationline">4.1.3. RestrictedInformationLine</a></li>
 <li><a href="#line-extension-Classification">4.1.4. Classification</a></li>
-<li><a href="#_invoiceseries">4.1.5. InvoiceSeries</a></li>
-<li><a href="#_languagecode">4.1.6. LanguageCode</a></li>
-<li><a href="#_supplytype">4.1.7. SupplyType</a></li>
-<li><a href="#_dutystamp">4.1.8. DutyStamp</a></li>
-<li><a href="#_igstonintra">4.1.9. IGSTOnIntra</a></li>
-<li><a href="#_billing_software">4.1.10. Billing Software</a></li>
-<li><a href="#_suppliergeneratedqrstring">4.1.11. SupplierGeneratedQRString</a></li>
-<li><a href="#_self_billing_indicator">4.1.12. Self Billing Indicator</a></li>
+<li><a href="#_suppliergeneratedqrstring">4.1.5. SupplierGeneratedQRString</a></li>
+<li><a href="#_supplytype">4.1.6. SupplyType</a></li>
+<li><a href="#_dutystamp">4.1.7. DutyStamp</a></li>
+<li><a href="#_igstonintra">4.1.8. IGSTOnIntra</a></li>
+<li><a href="#_billing_software">4.1.9. Billing Software</a></li>
+<li><a href="#_invoiceseries">4.1.10. InvoiceSeries</a></li>
+<li><a href="#_self_billing_indicator">4.1.11. Self Billing Indicator</a></li>
+<li><a href="#_simplified_indicator">4.1.12. Simplified Indicator</a></li>
 <li><a href="#_orderreference">4.1.13. OrderReference</a></li>
 <li><a href="#_billingreference">4.1.14. BillingReference</a></li>
 <li><a href="#_contractdocumentreference">4.1.15. ContractDocumentReference</a></li>
 <li><a href="#_party">4.1.16. Party</a></li>
 <li><a href="#_delivery">4.1.17. Delivery</a></li>
 <li><a href="#_paymentterms">4.1.18. PaymentTerms</a></li>
-<li><a href="#_prepaidpayment">4.1.19. PrepaidPayment</a></li>
-<li><a href="#_taxsubtotal">4.1.20. TaxSubTotal</a></li>
-<li><a href="#_legalmonetarytotal">4.1.21. LegalMonetaryTotal</a></li>
+<li><a href="#_taxsubtotal">4.1.19. TaxSubTotal</a></li>
+<li><a href="#_legalmonetarytotal">4.1.20. LegalMonetaryTotal</a></li>
+<li><a href="#_prepaidpayment">4.1.21. PrepaidPayment</a></li>
+<li><a href="#_languagecode">4.1.22. LanguageCode</a></li>
 </ul>
 </li>
 <li><a href="#_line_level">4.2. Line level</a>
@@ -787,28 +788,39 @@ table.CodeRay td.code{padding:0 0 0 .75em}
 <li><a href="#_routing_codes_dir3">5.15.1. Routing codes (DIR3)</a></li>
 </ul>
 </li>
-<li><a href="#_türkiye">5.16. Türkiye</a>
+<li><a href="#_spain_verifactu">5.16. Spain VeriFactu</a>
 <ul class="sectlevel3">
-<li><a href="#_invoice_profile_id">5.16.1. Invoice profile id</a></li>
-<li><a href="#_invoice_type_code">5.16.2. Invoice type code</a></li>
-<li><a href="#_invoice_delivery_method">5.16.3. Invoice delivery method</a></li>
-<li><a href="#_first_name_and_surname">5.16.4. First name and surname</a></li>
-<li><a href="#_registered_tax_office">5.16.5. Registered tax office</a></li>
-<li><a href="#_tax_category_codes_5">5.16.6. Tax category codes</a></li>
-<li><a href="#_tax_scheme">5.16.7. Tax scheme</a></li>
-<li><a href="#_internet_sales">5.16.8. Internet Sales</a></li>
+<li><a href="#_invoice_number_and_invoice_series">5.16.1. Invoice Number and Invoice Series</a></li>
+<li><a href="#_document_type_specification">5.16.2. Document Type Specification</a></li>
+<li><a href="#_simplified_invoice_indicator">5.16.3. Simplified Invoice Indicator</a></li>
+<li><a href="#_correction_information">5.16.4. Correction Information</a></li>
+<li><a href="#_party_identification_7">5.16.5. Party Identification</a></li>
+<li><a href="#_tax_details_2">5.16.6. Tax Details</a></li>
+<li><a href="#_related_resources">5.16.7. Related Resources</a></li>
 </ul>
 </li>
-<li><a href="#_united_states">5.17. United States</a>
+<li><a href="#_türkiye">5.17. Türkiye</a>
 <ul class="sectlevel3">
-<li><a href="#_tax_scheme_2">5.17.1. Tax scheme</a></li>
-<li><a href="#_party_identification_7">5.17.2. Party identification</a></li>
+<li><a href="#_invoice_profile_id">5.17.1. Invoice profile id</a></li>
+<li><a href="#_invoice_type_code">5.17.2. Invoice type code</a></li>
+<li><a href="#_invoice_delivery_method">5.17.3. Invoice delivery method</a></li>
+<li><a href="#_first_name_and_surname">5.17.4. First name and surname</a></li>
+<li><a href="#_registered_tax_office">5.17.5. Registered tax office</a></li>
+<li><a href="#_tax_category_codes_5">5.17.6. Tax category codes</a></li>
+<li><a href="#_tax_scheme">5.17.7. Tax scheme</a></li>
+<li><a href="#_internet_sales">5.17.8. Internet Sales</a></li>
 </ul>
 </li>
-<li><a href="#_vietnam">5.18. Vietnam</a>
+<li><a href="#_united_states">5.18. United States</a>
 <ul class="sectlevel3">
-<li><a href="#_invoice_serial_and_sequence_number">5.18.1. Invoice, Serial and Sequence Number</a></li>
-<li><a href="#_invoice_type_code_2">5.18.2. Invoice Type Code</a></li>
+<li><a href="#_tax_scheme_2">5.18.1. Tax scheme</a></li>
+<li><a href="#_party_identification_8">5.18.2. Party identification</a></li>
+</ul>
+</li>
+<li><a href="#_vietnam">5.19. Vietnam</a>
+<ul class="sectlevel3">
+<li><a href="#_invoice_serial_and_sequence_number">5.19.1. Invoice, Serial and Sequence Number</a></li>
+<li><a href="#_invoice_type_code_2">5.19.2. Invoice Type Code</a></li>
 </ul>
 </li>
 </ul>
@@ -7378,119 +7390,15 @@ Currency of the net amount related to the classification.</p></td>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_invoiceseries"><a class="anchor" href="#_invoiceseries"></a><a class="link" href="#_invoiceseries">4.1.5. InvoiceSeries</a></h4>
+<h4 id="_suppliergeneratedqrstring"><a class="anchor" href="#_suppliergeneratedqrstring"></a><a class="link" href="#_suppliergeneratedqrstring">4.1.5. SupplierGeneratedQRString</a></h4>
 <div class="paragraph">
-<p>The UBL extension to be used for below elements can be found <a href="#_cacbillingreference">here</a>.</p>
-</div>
-<div class="paragraph">
-<p>The structure used from <code>PUF-ExtensionComponent.xsd</code> is <code>PageroExtension/InvoiceSeries</code>.</p>
-</div>
-<div class="paragraph">
-<p><strong>Example</strong><br>
-<em>Example below how the URI is used for this extension.</em></p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
-    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
-    <span class="tag">&lt;cac:BillingReference&gt;</span>
-        <span class="tag">&lt;cac:InvoiceDocumentReference&gt;</span>
-            <span class="tag">&lt;ext:UBLExtensions&gt;</span>
-                <span class="tag">&lt;ext:UBLExtension&gt;</span>
-                    <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:InvoiceSeries<span class="tag">&lt;/ext:ExtensionURI&gt;</span> <i class="conum" data-value="1"></i><b>(1)</b>
-                    <span class="tag">&lt;ext:ExtensionContent&gt;</span>
-                        <span class="tag">&lt;puf:PageroExtension&gt;</span>
-                            <span class="tag">&lt;puf:InvoiceSeries</span><span class="tag">/&gt;</span> <i class="conum" data-value="2"></i><b>(2)</b>
-                        <span class="tag">&lt;/puf:PageroExtension&gt;</span>
-                    <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
-                <span class="tag">&lt;/ext:UBLExtension&gt;</span>
-            <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
-        <span class="tag">&lt;/cac:InvoiceDocumentReference&gt;</span>
-    <span class="tag">&lt;/cac:BillingReference&gt;</span>
-    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
-<span class="tag">&lt;/Invoice&gt;</span></code></pre>
-</div>
-</div>
-<div class="colist arabic">
-<table>
-<tr>
-<td><i class="conum" data-value="1"></i><b>1</b></td>
-<td>URI to be used if this extension is added.</td>
-</tr>
-<tr>
-<td><i class="conum" data-value="2"></i><b>2</b></td>
-<td>Structure to be used if information from this extension will be used.</td>
-</tr>
-</table>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 42. Elements added in puf:BillingReferenceExtension</caption>
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Element</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cbc:ID</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Invoice series identifier</strong><br>
-Identifier used for the series the document is part of.</p></td>
-</tr>
-</tbody>
-</table>
-<div class="paragraph">
-<p><strong>Example</strong><br>
-<em>Invoice Series example</em></p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
-    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
-    <span class="tag">&lt;ext:UBLExtensions&gt;</span>
-        <span class="tag">&lt;ext:UBLExtension&gt;</span>
-            <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:InvoiceSeries<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
-            <span class="tag">&lt;ext:ExtensionContent&gt;</span>
-                <span class="tag">&lt;puf:PageroExtension&gt;</span>
-                    <span class="tag">&lt;puf:InvoiceSeries&gt;</span>
-                        <span class="tag">&lt;cbc:ID&gt;</span>InvSeries<span class="tag">&lt;/cbc:ID&gt;</span>
-                    <span class="tag">&lt;/puf:InvoiceSeries&gt;</span>
-                <span class="tag">&lt;/puf:PageroExtension&gt;</span>
-            <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
-        <span class="tag">&lt;/ext:UBLExtension&gt;</span>
-    <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
-    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
-<span class="tag">&lt;/Invoice&gt;</span></code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_languagecode"><a class="anchor" href="#_languagecode"></a><a class="link" href="#_languagecode">4.1.6. LanguageCode</a></h4>
-<div class="paragraph">
-<p>In order to specify language code for the system generated PDF presentation in Pagero Online, a segment for this is added as Extension.</p>
-</div>
-<div class="admonitionblock warning">
-<table>
-<tr>
-<td class="icon">
-<i class="fa icon-warning" title="Warning"></i>
-</td>
-<td class="content">
-Note that not all languages are supported in Pagero Online.<br>
-Please contact us to learn which languages are available.
-</td>
-</tr>
-</table>
+<p>In order to provide a supplier generated QR string following elements has been added in the below extension.</p>
 </div>
 <div class="paragraph">
 <p>The UBL extension to be used for below elements can be found <a href="#_extublextensions">here</a>.</p>
 </div>
 <div class="paragraph">
-<p>The structure used from <code>PUF-ExtensionComponent.xsd</code> is <code>PageroExtension/LanguageCode</code>.</p>
+<p>The structure used from <code>PUF-ExtensionComponent.xsd</code> is <code>PageroExtension/QRExtension</code>.</p>
 </div>
 <div class="paragraph">
 <p>See example below as well as the URI to be used for this extension.</p>
@@ -7503,10 +7411,13 @@ Please contact us to learn which languages are available.
 <pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
   <span class="tag">&lt;ext:UBLExtensions&gt;</span>
       <span class="tag">&lt;ext:UBLExtension&gt;</span>
-          <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:LanguageCode<span class="tag">&lt;/ext:ExtensionURI&gt;</span> <i class="conum" data-value="1"></i><b>(1)</b>
+          <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:QRExtension<span class="tag">&lt;/ext:ExtensionURI&gt;</span> <i class="conum" data-value="1"></i><b>(1)</b>
           <span class="tag">&lt;ext:ExtensionContent&gt;</span>
               <span class="tag">&lt;puf:PageroExtension&gt;</span>
-                <span class="tag">&lt;puf:LanguageCode</span><span class="tag">/&gt;</span> <i class="conum" data-value="2"></i><b>(2)</b>
+                <span class="tag">&lt;puf:SupplierGeneratedQRString&gt;</span> <i class="conum" data-value="2"></i><b>(2)</b>
+                    <span class="tag">&lt;puf:QRString&gt;</span>TheQRCode<span class="tag">&lt;/puf:QRString&gt;</span>
+                    <span class="tag">&lt;puf:QREncodingType&gt;</span>TEXT<span class="tag">&lt;/puf:QREncodingType&gt;</span>
+                <span class="tag">&lt;/puf:SupplierGeneratedQRString&gt;</span>
               <span class="tag">&lt;/puf:PageroExtension&gt;</span>
           <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
       <span class="tag">&lt;/ext:UBLExtension&gt;</span>
@@ -7531,7 +7442,7 @@ Please contact us to learn which languages are available.
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 43. Elements added to puf:PageroExtension/puf:LanguageCode</caption>
+<caption class="title">Table 42. Elements added to puf:PageroExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -7544,36 +7455,42 @@ Please contact us to learn which languages are available.
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:LanguageCode</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Language Code</strong><br>
-Must be in lower case alpha, ISO 639-1, format.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:SupplierGeneratedQRString/puf:QRString</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Supplier generated QR string</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:SupplierGeneratedQRString/puf:QREncodingType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Value must be <strong>TEXT</strong> or <strong>BASE64</strong> depending on if the QR string is expressed as a text string or base 64 encoded</p></td>
 </tr>
 </tbody>
 </table>
 <div class="paragraph">
 <p><strong>Example</strong><br>
-<em>Language Code</em></p>
+<em>QR string provided as plain text</em></p>
 </div>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
-    <span class="tag">&lt;ext:UBLExtensions&gt;</span>
-        <span class="tag">&lt;ext:UBLExtension&gt;</span>
-            <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:LanguageCode<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
-            <span class="tag">&lt;ext:ExtensionContent&gt;</span>
-                <span class="tag">&lt;puf:PageroExtension&gt;</span>
-                    <span class="tag">&lt;puf:LanguageCode&gt;</span>en<span class="tag">&lt;/puf:LanguageCode&gt;</span>
+  <span class="tag">&lt;ext:UBLExtensions&gt;</span>
+      <span class="tag">&lt;ext:UBLExtension&gt;</span>
+          <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:IGSTOnIntra<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
+          <span class="tag">&lt;ext:ExtensionContent&gt;</span>
+              <span class="tag">&lt;puf:PageroExtension&gt;</span>
+                    <span class="tag">&lt;puf:SupplierGeneratedQRString&gt;</span>
+                        <span class="tag">&lt;puf:QRString&gt;</span>TheQRCode<span class="tag">&lt;/puf:QRString&gt;</span>
+                        <span class="tag">&lt;puf:QREncodingType&gt;</span>TEXT<span class="tag">&lt;/puf:QREncodingType&gt;</span>
+                    <span class="tag">&lt;/puf:SupplierGeneratedQRString&gt;</span>
                 <span class="tag">&lt;/puf:PageroExtension&gt;</span>
-            <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
-        <span class="tag">&lt;/ext:UBLExtension&gt;</span>
-    <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
-    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+          <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
+      <span class="tag">&lt;/ext:UBLExtension&gt;</span>
+  <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+  <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
 <span class="tag">&lt;/Invoice&gt;</span></code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_supplytype"><a class="anchor" href="#_supplytype"></a><a class="link" href="#_supplytype">4.1.7. SupplyType</a></h4>
+<h4 id="_supplytype"><a class="anchor" href="#_supplytype"></a><a class="link" href="#_supplytype">4.1.6. SupplyType</a></h4>
 <div class="paragraph">
 <p>In order to specify a supply type for the invoice, following elements has been added in the below extension.</p>
 </div>
@@ -7622,7 +7539,7 @@ Must be in lower case alpha, ISO 639-1, format.</p></td>
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 44. Elements added to puf:PageroExtension/puf:SupplyType</caption>
+<caption class="title">Table 43. Elements added to puf:PageroExtension/puf:SupplyType</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -7666,7 +7583,7 @@ Code describing the type of supply.</p></td>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_dutystamp"><a class="anchor" href="#_dutystamp"></a><a class="link" href="#_dutystamp">4.1.8. DutyStamp</a></h4>
+<h4 id="_dutystamp"><a class="anchor" href="#_dutystamp"></a><a class="link" href="#_dutystamp">4.1.7. DutyStamp</a></h4>
 <div class="paragraph">
 <p>In order to specify a duty stamp for the invoice, following elements has been added in the below extension.</p>
 </div>
@@ -7715,7 +7632,7 @@ Code describing the type of supply.</p></td>
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 45. Elements added to puf:PageroExtension/puf:DutyStamp</caption>
+<caption class="title">Table 44. Elements added to puf:PageroExtension/puf:DutyStamp</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -7765,7 +7682,7 @@ For valid values see code list <a href="https://pagero.github.io/puf-code-lists/
 </div>
 </div>
 <div class="sect3">
-<h4 id="_igstonintra"><a class="anchor" href="#_igstonintra"></a><a class="link" href="#_igstonintra">4.1.9. IGSTOnIntra</a></h4>
+<h4 id="_igstonintra"><a class="anchor" href="#_igstonintra"></a><a class="link" href="#_igstonintra">4.1.8. IGSTOnIntra</a></h4>
 <div class="paragraph">
 <p>In order to specify if IGST (Integrated Goods and Services Tax) is applicable on intra state supplies the following elements has been added in the below extension.</p>
 </div>
@@ -7814,7 +7731,7 @@ For valid values see code list <a href="https://pagero.github.io/puf-code-lists/
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 46. Elements added to puf:PageroExtension</caption>
+<caption class="title">Table 45. Elements added to puf:PageroExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -7857,7 +7774,7 @@ To indicate if supply is chargeable to IGST despite the fact that the Supplier a
 </div>
 </div>
 <div class="sect3">
-<h4 id="_billing_software"><a class="anchor" href="#_billing_software"></a><a class="link" href="#_billing_software">4.1.10. Billing Software</a></h4>
+<h4 id="_billing_software"><a class="anchor" href="#_billing_software"></a><a class="link" href="#_billing_software">4.1.9. Billing Software</a></h4>
 <div class="paragraph">
 <p>In order to specify information about a billing software, following elements has been added in the below extension.</p>
 </div>
@@ -7906,7 +7823,7 @@ To indicate if supply is chargeable to IGST despite the fact that the Supplier a
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 47. Elements added to puf:PageroExtension/puf:BillingSoftware</caption>
+<caption class="title">Table 46. Elements added to puf:PageroExtension/puf:BillingSoftware</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -7962,39 +7879,36 @@ Description of the software identification (free text).<br></p></td>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_suppliergeneratedqrstring"><a class="anchor" href="#_suppliergeneratedqrstring"></a><a class="link" href="#_suppliergeneratedqrstring">4.1.11. SupplierGeneratedQRString</a></h4>
+<h4 id="_invoiceseries"><a class="anchor" href="#_invoiceseries"></a><a class="link" href="#_invoiceseries">4.1.10. InvoiceSeries</a></h4>
 <div class="paragraph">
-<p>In order to provide a supplier generated QR string following elements has been added in the below extension.</p>
+<p>The UBL extension to be used for below elements can be found <a href="#_cacbillingreference">here</a>.</p>
 </div>
 <div class="paragraph">
-<p>The UBL extension to be used for below elements can be found <a href="#_extublextensions">here</a>.</p>
+<p>The structure used from <code>PUF-ExtensionComponent.xsd</code> is <code>PageroExtension/InvoiceSeries</code>.</p>
 </div>
 <div class="paragraph">
-<p>The structure used from <code>PUF-ExtensionComponent.xsd</code> is <code>PageroExtension/QRExtension</code>.</p>
-</div>
-<div class="paragraph">
-<p>See example below as well as the URI to be used for this extension.</p>
-</div>
-<div class="paragraph">
-<p><strong>Example</strong><br></p>
+<p><strong>Example</strong><br>
+<em>Example below how the URI is used for this extension.</em></p>
 </div>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
-  <span class="tag">&lt;ext:UBLExtensions&gt;</span>
-      <span class="tag">&lt;ext:UBLExtension&gt;</span>
-          <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:QRExtension<span class="tag">&lt;/ext:ExtensionURI&gt;</span> <i class="conum" data-value="1"></i><b>(1)</b>
-          <span class="tag">&lt;ext:ExtensionContent&gt;</span>
-              <span class="tag">&lt;puf:PageroExtension&gt;</span>
-                <span class="tag">&lt;puf:SupplierGeneratedQRString&gt;</span> <i class="conum" data-value="2"></i><b>(2)</b>
-                    <span class="tag">&lt;puf:QRString&gt;</span>TheQRCode<span class="tag">&lt;/puf:QRString&gt;</span>
-                    <span class="tag">&lt;puf:QREncodingType&gt;</span>TEXT<span class="tag">&lt;/puf:QREncodingType&gt;</span>
-                <span class="tag">&lt;/puf:SupplierGeneratedQRString&gt;</span>
-              <span class="tag">&lt;/puf:PageroExtension&gt;</span>
-          <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
-      <span class="tag">&lt;/ext:UBLExtension&gt;</span>
-  <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
-  <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+    <span class="tag">&lt;cac:BillingReference&gt;</span>
+        <span class="tag">&lt;cac:InvoiceDocumentReference&gt;</span>
+            <span class="tag">&lt;ext:UBLExtensions&gt;</span>
+                <span class="tag">&lt;ext:UBLExtension&gt;</span>
+                    <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:InvoiceSeries<span class="tag">&lt;/ext:ExtensionURI&gt;</span> <i class="conum" data-value="1"></i><b>(1)</b>
+                    <span class="tag">&lt;ext:ExtensionContent&gt;</span>
+                        <span class="tag">&lt;puf:PageroExtension&gt;</span>
+                            <span class="tag">&lt;puf:InvoiceSeries</span><span class="tag">/&gt;</span> <i class="conum" data-value="2"></i><b>(2)</b>
+                        <span class="tag">&lt;/puf:PageroExtension&gt;</span>
+                    <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
+                <span class="tag">&lt;/ext:UBLExtension&gt;</span>
+            <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+        <span class="tag">&lt;/cac:InvoiceDocumentReference&gt;</span>
+    <span class="tag">&lt;/cac:BillingReference&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
 <span class="tag">&lt;/Invoice&gt;</span></code></pre>
 </div>
 </div>
@@ -8010,11 +7924,8 @@ Description of the software identification (free text).<br></p></td>
 </tr>
 </table>
 </div>
-<div class="paragraph">
-<p>Below table shows the definition of the new elements added to the extension.</p>
-</div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 48. Elements added to puf:PageroExtension</caption>
+<caption class="title">Table 47. Elements added in puf:BillingReferenceExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -8027,42 +7938,39 @@ Description of the software identification (free text).<br></p></td>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:SupplierGeneratedQRString/puf:QRString</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Supplier generated QR string</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:SupplierGeneratedQRString/puf:QREncodingType</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Value must be <strong>TEXT</strong> or <strong>BASE64</strong> depending on if the QR string is expressed as a text string or base 64 encoded</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cbc:ID</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Invoice series identifier</strong><br>
+Identifier used for the series the document is part of.</p></td>
 </tr>
 </tbody>
 </table>
 <div class="paragraph">
 <p><strong>Example</strong><br>
-<em>QR string provided as plain text</em></p>
+<em>Invoice Series example</em></p>
 </div>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
-  <span class="tag">&lt;ext:UBLExtensions&gt;</span>
-      <span class="tag">&lt;ext:UBLExtension&gt;</span>
-          <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:IGSTOnIntra<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
-          <span class="tag">&lt;ext:ExtensionContent&gt;</span>
-              <span class="tag">&lt;puf:PageroExtension&gt;</span>
-                    <span class="tag">&lt;puf:SupplierGeneratedQRString&gt;</span>
-                        <span class="tag">&lt;puf:QRString&gt;</span>TheQRCode<span class="tag">&lt;/puf:QRString&gt;</span>
-                        <span class="tag">&lt;puf:QREncodingType&gt;</span>TEXT<span class="tag">&lt;/puf:QREncodingType&gt;</span>
-                    <span class="tag">&lt;/puf:SupplierGeneratedQRString&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+    <span class="tag">&lt;ext:UBLExtensions&gt;</span>
+        <span class="tag">&lt;ext:UBLExtension&gt;</span>
+            <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:InvoiceSeries<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
+            <span class="tag">&lt;ext:ExtensionContent&gt;</span>
+                <span class="tag">&lt;puf:PageroExtension&gt;</span>
+                    <span class="tag">&lt;puf:InvoiceSeries&gt;</span>
+                        <span class="tag">&lt;cbc:ID&gt;</span>InvSeries<span class="tag">&lt;/cbc:ID&gt;</span>
+                    <span class="tag">&lt;/puf:InvoiceSeries&gt;</span>
                 <span class="tag">&lt;/puf:PageroExtension&gt;</span>
-          <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
-      <span class="tag">&lt;/ext:UBLExtension&gt;</span>
-  <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
-  <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+            <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
+        <span class="tag">&lt;/ext:UBLExtension&gt;</span>
+    <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
 <span class="tag">&lt;/Invoice&gt;</span></code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_self_billing_indicator"><a class="anchor" href="#_self_billing_indicator"></a><a class="link" href="#_self_billing_indicator">4.1.12. Self Billing Indicator</a></h4>
+<h4 id="_self_billing_indicator"><a class="anchor" href="#_self_billing_indicator"></a><a class="link" href="#_self_billing_indicator">4.1.11. Self Billing Indicator</a></h4>
 <div class="paragraph">
 <p>In order to indicate that the document is self-billed, a segment for this is added as Extension.</p>
 </div>
@@ -8124,7 +8032,7 @@ Please contact Pagero to learn in which markets we support self-billing.
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 49. Elements added to puf:PageroExtension/puf:SelfBilled</caption>
+<caption class="title">Table 48. Elements added to puf:PageroExtension/puf:SelfBilled</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -8157,6 +8065,112 @@ Can either be <strong>true</strong> or <strong>false</strong>.<br>
             <span class="tag">&lt;ext:ExtensionContent&gt;</span>
                 <span class="tag">&lt;puf:PageroExtension&gt;</span>
                     <span class="tag">&lt;puf:SelfBilled&gt;</span>true<span class="tag">&lt;/puf:SelfBilled&gt;</span>
+                <span class="tag">&lt;/puf:PageroExtension&gt;</span>
+            <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
+        <span class="tag">&lt;/ext:UBLExtension&gt;</span>
+    <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+<span class="tag">&lt;/Invoice&gt;</span></code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_simplified_indicator"><a class="anchor" href="#_simplified_indicator"></a><a class="link" href="#_simplified_indicator">4.1.12. Simplified Indicator</a></h4>
+<div class="paragraph">
+<p>This indicator can be used in conjunction with the regular invoice types to indicate if it is a simplified invoice, simplified credit note etc.<br>
+Please note that what is to be considered as simplified may vary between different countries (for example invoices below a certain amount etc).</p>
+</div>
+<div class="admonitionblock warning">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-warning" title="Warning"></i>
+</td>
+<td class="content">
+Note that not all markets are supported in Pagero Online.<br>
+Please contact Pagero to learn in which markets we support simplified invoice in.
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>The UBL extension to be used for below elements can be found <a href="#_extublextensions">here</a>.</p>
+</div>
+<div class="paragraph">
+<p>The structure used from <code>PUF-ExtensionComponent.xsd</code> is <code>PageroExtension/Simplified</code>.</p>
+</div>
+<div class="paragraph">
+<p>See example below as well as the URI to be used for this extension.</p>
+</div>
+<div class="paragraph">
+<p><strong>Example</strong><br></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
+  <span class="tag">&lt;ext:UBLExtensions&gt;</span>
+      <span class="tag">&lt;ext:UBLExtension&gt;</span>
+          <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:Simplified<span class="tag">&lt;/ext:ExtensionURI&gt;</span> <i class="conum" data-value="1"></i><b>(1)</b>
+          <span class="tag">&lt;ext:ExtensionContent&gt;</span>
+              <span class="tag">&lt;puf:PageroExtension&gt;</span>
+                <span class="tag">&lt;puf:Simplified</span><span class="tag">/&gt;</span> <i class="conum" data-value="2"></i><b>(2)</b>
+              <span class="tag">&lt;/puf:PageroExtension&gt;</span>
+          <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
+      <span class="tag">&lt;/ext:UBLExtension&gt;</span>
+  <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+  <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+<span class="tag">&lt;/Invoice&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>URI to be used if this extension is added.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Structure to be used if information from this extension will be used.</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>Below table shows the definition of the elements added to the extension.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 49. Elements added to puf:PageroExtension/puf:Simplified</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Element</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:Simplified</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Simplified Invoice Indicator</strong><br>
+Can either be <strong>true</strong> or <strong>false</strong>.<br>
+<strong>Note that if the element is missing Pagero Online treat it as false</strong></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p><strong>Example</strong><br>
+<em>Simplified Invoice</em></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
+    <span class="tag">&lt;ext:UBLExtensions&gt;</span>
+        <span class="tag">&lt;ext:UBLExtension&gt;</span>
+            <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:Simplified<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
+            <span class="tag">&lt;ext:ExtensionContent&gt;</span>
+                <span class="tag">&lt;puf:PageroExtension&gt;</span>
+                    <span class="tag">&lt;puf:Simplified&gt;</span>true<span class="tag">&lt;/puf:Simplified&gt;</span>
                 <span class="tag">&lt;/puf:PageroExtension&gt;</span>
             <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
         <span class="tag">&lt;/ext:UBLExtension&gt;</span>
@@ -8345,6 +8359,26 @@ Code signifying the reason for credit.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Clearance ID of the referenced document</strong><br>
 ID, usually assigned by the Tax Authority, of the referenced document e.g. UUID in Malaysia.</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:RestrictedInformation</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Restricted information</strong><br>
+Key-value pairs for additional country-specific information related to the billing reference. Can be repeated multiple times.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cbc:TaxableAmount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Referenced document tax base amount</strong><br>
+The tax base amount of the referenced document. Used in some countries for corrections (e.g., Spain substitutive method).</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cbc:TaxAmount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Referenced document tax amount</strong><br>
+The tax amount of the referenced document. Used in some countries for corrections (e.g., Spain substitutive method).</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:EquivalenceSurchargeAmount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Referenced document equivalence surcharge amount</strong><br>
+The equivalence surcharge amount of the referenced document. Used in Spain for corrections when equivalence surcharge applies.</p></td>
+</tr>
 </tbody>
 </table>
 <div class="paragraph">
@@ -8371,6 +8405,15 @@ ID, usually assigned by the Tax Authority, of the referenced document e.g. UUID 
                                 <span class="comment">&lt;!-- Reason for credit in code form, if applicable --&gt;</span>
                                 <span class="tag">&lt;puf:Code&gt;</span>codeValue<span class="tag">&lt;/puf:Code&gt;</span>
                                 <span class="tag">&lt;puf:ClearanceID&gt;</span>Clearance ID<span class="tag">&lt;/puf:ClearanceID&gt;</span>
+                                <span class="comment">&lt;!-- Additional country-specific information, if applicable --&gt;</span>
+                                <span class="tag">&lt;puf:RestrictedInformation&gt;</span>
+                                    <span class="tag">&lt;puf:Key&gt;</span>CountrySpecificKey<span class="tag">&lt;/puf:Key&gt;</span>
+                                    <span class="tag">&lt;puf:Value&gt;</span>CountrySpecificValue<span class="tag">&lt;/puf:Value&gt;</span>
+                                <span class="tag">&lt;/puf:RestrictedInformation&gt;</span>
+                                <span class="comment">&lt;!-- Referenced document amounts, if applicable (e.g., Spain substitutive corrections) --&gt;</span>
+                                <span class="tag">&lt;cbc:TaxableAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>1000.00<span class="tag">&lt;/cbc:TaxableAmount&gt;</span>
+                                <span class="tag">&lt;cbc:TaxAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>210.00<span class="tag">&lt;/cbc:TaxAmount&gt;</span>
+                                <span class="tag">&lt;puf:EquivalenceSurchargeAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>52.00<span class="tag">&lt;/puf:EquivalenceSurchargeAmount&gt;</span>
                             <span class="tag">&lt;/puf:BillingReferenceExtension&gt;</span>
                         <span class="tag">&lt;/puf:PageroExtension&gt;</span>
                     <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
@@ -8929,208 +8972,7 @@ Penalty text due to late payment, if the need of explicitly stating a penalty te
 </div>
 </div>
 <div class="sect3">
-<h4 id="_prepaidpayment"><a class="anchor" href="#_prepaidpayment"></a><a class="link" href="#_prepaidpayment">4.1.19. PrepaidPayment</a></h4>
-<div class="paragraph">
-<p>The UBL extension to be used for below elements can be found <a href="#_cacprepaidpayment">here</a>.</p>
-</div>
-<div class="paragraph">
-<p>The structure used from <code>PUF-ExtensionComponent.xsd</code> is <code>puf:PageroExtension/puf:PrepaidPaymentExtension</code>.</p>
-</div>
-<div class="paragraph">
-<p>See example below as well as the URI to be used for this extension.</p>
-</div>
-<div class="paragraph">
-<p><strong>Example</strong></p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
-<span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
-    <span class="tag">&lt;cac:PrepaidPayment&gt;</span>
-            <span class="tag">&lt;ext:UBLExtensions&gt;</span>
-                <span class="tag">&lt;ext:UBLExtension&gt;</span>
-                    <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:PrepaidPaymentExtension<span class="tag">&lt;/ext:ExtensionURI&gt;</span> <i class="conum" data-value="1"></i><b>(1)</b>
-                        <span class="tag">&lt;ext:ExtensionContent&gt;</span>
-                            <span class="tag">&lt;puf:PageroExtension&gt;</span>
-                                <span class="tag">&lt;puf:PrepaidPaymentExtension</span><span class="tag">/&gt;</span> <i class="conum" data-value="2"></i><b>(2)</b>
-                        <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
-                <span class="tag">&lt;/ext:UBLExtension&gt;</span>
-            <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
-    <span class="tag">&lt;/cac:PrepaidPayment&gt;</span>
-<span class="tag">&lt;/Invoice&gt;</span></code></pre>
-</div>
-</div>
-<div class="colist arabic">
-<table>
-<tr>
-<td><i class="conum" data-value="1"></i><b>1</b></td>
-<td>URI to be used if this extension is added.</td>
-</tr>
-<tr>
-<td><i class="conum" data-value="2"></i><b>2</b></td>
-<td>Structure to be used if information from this extension will be used.</td>
-</tr>
-</table>
-</div>
-<div class="paragraph">
-<p>Below table shows the definition of the extended element.</p>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 56. Elements added in puf:PrepaidPaymentExtension</caption>
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Element</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:DocumentReference/cbc:ID</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Prepayment invoice number ID</strong><br>
-The invoice number of the associated prepayment invoice.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:DocumentReference/cbc:IssueDate</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Prepayment invoice issue date</strong><br>
-Issue date of associated prepayment invoice.<br>
-<em>Format "YYYY-MM-DD". of the associated prepayment invoice.</em></p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:DocumentReference/cbc:IssueTime</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Prepayment invoice issue time</strong><br>
-Issue time of associated prepayment invoice.<br>
-<em>Format "HH:mm:ss", "HH:mm:ssZZZZ", "HH:mm:ss.SSS’Z'", or "HH:mm:ss.SSS".</em></p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:DocumentReference/cbc:DocumentTypeCode</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Document type code</strong><br>
-Document type code should be '386' when referencing a prepayment invoice.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cbc:Description</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Name/Description of the prepayment</strong><br>
-Description of the prepayment (free text).</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:TaxTotal/cbc:TaxAmount</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Total tax amount</strong><br>
-Prepayment invoice total tax amount in document currency.<br>
-<em>Summary of all cac:TaxSubTotal/cbc:TaxAmount of the prepayment.</em></p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:TaxTotal/cbc:TaxAmount/@currencyID</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Total tax amount currency</strong><br>
-Prepayment invoice total tax amount currency, must be the same as <code>cbc:DocumentCurrencyCode</code>.<br>
-For valid values see code list <a href="https://pagero.github.io/puf-code-lists/#_puf_004_currencycode" target="_blank" rel="noopener">PUF-004-CURRENCYCODE</a>.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:TaxTotal/cac:TaxSubtotal/cbc:TaxableAmount</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Total taxable amount for each tax category</strong><br>
-Total taxable amount for each tax category or tax rate.<br>
-<em>E.g. Summary of all taxable amounts for invoice lines with a certain tax percent.</em></p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:TaxSubtotal/cbc:TaxableAmount/@currencyID</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Total taxable amount for each tax category currency</strong><br>
-Total taxable amount currency, must be the same as <code>cbc:DocumentCurrencyCode</code>.<br>
-For valid values see code list <a href="https://pagero.github.io/puf-code-lists/#_puf_004_currencycode" target="_blank" rel="noopener">PUF-004-CURRENCYCODE</a>.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:TaxSubtotal/cbc:TaxAmount</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Total tax amount for each tax category</strong><br>
-Total tax amount for a certain tax category or tax rate.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:TaxSubtotal/cbc:TaxAmount/@currencyID</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Total tax amount currency for each tax category</strong><br>
-Total tax amount currency, must be the same as <code>cbc:DocumentCurrencyCode</code>.<br>
-For valid values see code list <a href="https://pagero.github.io/puf-code-lists/#_puf_004_currencycode" target="_blank" rel="noopener">PUF-004-CURRENCYCODE</a>.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:TaxSubtotal/cac:TaxCategory/cbc:ID</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Tax category code</strong><br>
-Code for identifying the tax category.<br>
-<em>E.g. tax category "S".</em><br>
-For valid values see code list <a href="https://pagero.github.io/puf-code-lists/#_puf_012_taxcategorycode" target="_blank" rel="noopener">PUF-012-TAXCATEGORYCODE</a>.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:TaxSubtotal/cac:TaxCategory/cbc:Percent</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Tax category percent</strong><br>
-Percentage rate for the tax category.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:TaxSubtotal/cac:TaxCategory/cbc:TaxExemptionReasonCode</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Tax exemption reason code</strong><br>
-Exemption reason code for the tax category, only applicable if the goods or service is exempt from tax.<br>
-See code list <a href="https://pagero.github.io/puf-code-lists/#_puf_013_taxexemptioncode" target="_blank" rel="noopener">PUF-013-TAXEXEMPTIONCODE</a> for recommendations.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:TaxSubtotal/cac:TaxCategory/cbc:TaxExemptionReason</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Tax exemption reason</strong><br>
-Exemption reason for the tax category, only applicable if the goods or service is exempt from tax.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:TaxSubtotal/cac:TaxCategory/cac:TaxScheme/cbc:ID</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Tax scheme identfier</strong><br>
-Tax scheme for the tax category.<br>
-For valid values see code list <a href="https://pagero.github.io/puf-code-lists/#_puf_009_taxtypescheme" target="_blank" rel="noopener">PUF-009-TAXTYPESCHEME</a>.</p></td>
-</tr>
-</tbody>
-</table>
-<div class="paragraph">
-<p><strong>Example</strong><br>
-<em>cac:PrepaidPayment example</em></p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
-  <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
-  <span class="tag">&lt;cac:PrepaidPayment&gt;</span>
-        <span class="tag">&lt;ext:UBLExtensions&gt;</span>
-            <span class="tag">&lt;ext:UBLExtension&gt;</span>
-                <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:PrepaidPaymentExtension<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
-                    <span class="tag">&lt;ext:ExtensionContent&gt;</span>
-                        <span class="tag">&lt;puf:PageroExtension&gt;</span>
-                            <span class="tag">&lt;puf:PrepaidPaymentExtension&gt;</span>
-                                <span class="tag">&lt;cac:DocumentReference&gt;</span>
-                                    <span class="tag">&lt;cbc:ID&gt;</span>46531<span class="tag">&lt;/cbc:ID&gt;</span>
-                                    <span class="tag">&lt;cbc:IssueDate&gt;</span>2021-07-31<span class="tag">&lt;/cbc:IssueDate&gt;</span>
-                                    <span class="tag">&lt;cbc:IssueTime&gt;</span>12:28:17<span class="tag">&lt;/cbc:IssueTime&gt;</span>
-                                    <span class="tag">&lt;cbc:DocumentTypeCode&gt;</span>386<span class="tag">&lt;/cbc:DocumentTypeCode&gt;</span>
-                                <span class="tag">&lt;/cac:DocumentReference&gt;</span>
-                                <span class="tag">&lt;cbc:Description&gt;</span>Prepayment adjustment<span class="tag">&lt;/cbc:Description&gt;</span>
-                                <span class="tag">&lt;cac:TaxTotal&gt;</span>
-                                    <span class="tag">&lt;cbc:TaxAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">SAR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>1.50<span class="tag">&lt;/cbc:TaxAmount&gt;</span>
-                                    <span class="tag">&lt;cac:TaxSubtotal&gt;</span>
-                                        <span class="tag">&lt;cbc:TaxableAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">SAR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>10.00<span class="tag">&lt;/cbc:TaxableAmount&gt;</span>
-                                        <span class="tag">&lt;cbc:TaxAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">SAR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>1.50<span class="tag">&lt;/cbc:TaxAmount&gt;</span>
-                                        <span class="tag">&lt;cac:TaxCategory&gt;</span>
-                                            <span class="tag">&lt;cbc:ID&gt;</span>S<span class="tag">&lt;/cbc:ID&gt;</span>
-                                            <span class="tag">&lt;cbc:Percent&gt;</span>15.00<span class="tag">&lt;/cbc:Percent&gt;</span>
-                                            <span class="tag">&lt;cac:TaxScheme&gt;</span>
-                                                <span class="tag">&lt;cbc:ID&gt;</span>VAT<span class="tag">&lt;/cbc:ID&gt;</span>
-                                            <span class="tag">&lt;/cac:TaxScheme&gt;</span>
-                                        <span class="tag">&lt;/cac:TaxCategory&gt;</span>
-                                    <span class="tag">&lt;/cac:TaxSubtotal&gt;</span>
-                                <span class="tag">&lt;/cac:TaxTotal&gt;</span>
-                            <span class="tag">&lt;/puf:PrepaidPaymentExtension&gt;</span>
-                        <span class="tag">&lt;/puf:PageroExtension&gt;</span>
-                    <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
-            <span class="tag">&lt;/ext:UBLExtension&gt;</span>
-        <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
-        <span class="tag">&lt;cbc:PaidAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">SAR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>11.50<span class="tag">&lt;/cbc:PaidAmount&gt;</span>
-    <span class="tag">&lt;/cac:PrepaidPayment&gt;</span>
-  <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
-<span class="tag">&lt;/Invoice&gt;</span></code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_taxsubtotal"><a class="anchor" href="#_taxsubtotal"></a><a class="link" href="#_taxsubtotal">4.1.20. TaxSubTotal</a></h4>
+<h4 id="_taxsubtotal"><a class="anchor" href="#_taxsubtotal"></a><a class="link" href="#_taxsubtotal">4.1.19. TaxSubTotal</a></h4>
 <div class="paragraph">
 <p>The UBL extension to be used for below elements can be found <a href="#_cactaxtotal">here</a>.</p>
 </div>
@@ -9182,7 +9024,7 @@ For valid values see code list <a href="https://pagero.github.io/puf-code-lists/
 <p>Below table lists all additional elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 57. Elements added in puf:TaxSubtotalExtension</caption>
+<caption class="title">Table 56. Elements added in puf:TaxSubtotalExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -9195,6 +9037,22 @@ For valid values see code list <a href="https://pagero.github.io/puf-code-lists/
 </thead>
 <tbody>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:SpecialRegimeKey</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Special regime key</strong><br>
+Code identifying the special tax regime or transaction type. Mandatory in some countries (e.g., Spain VeriFactu ClaveRegimen).<br>
+For valid values see code list <a href="https://pagero.github.io/puf-code-lists/#_puf_022_specialregimekey" target="_blank" rel="noopener">PUF-022-SPECIALREGIMEKEY</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:TaxBaseAtCost</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Tax base at cost</strong><br>
+Tax base calculated at cost for special group regimes. Used in certain countries (e.g., Spain) for specific tax regime scenarios.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:TaxBaseAtCost/@currencyID</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Currency of TaxBaseAtCost</strong><br>
+For valid values see code list <a href="https://pagero.github.io/puf-code-lists/#_puf_004_currencycode" target="_blank" rel="noopener">PUF-004-CURRENCYCODE</a>.</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:TaxCurrencyTaxableAmount</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Tax currency taxable amount</strong><br>
 Taxable amount in tax currency per subtotal.</p></td>
@@ -9202,7 +9060,7 @@ Taxable amount in tax currency per subtotal.</p></td>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:TaxCurrencyTaxableAmount/@currencyID</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Tax currency taxable amount currency</strong><br>
-Currency of taxable amount in tax currency per subtotal.</p></td>
+For valid values see code list <a href="https://pagero.github.io/puf-code-lists/#_puf_004_currencycode" target="_blank" rel="noopener">PUF-004-CURRENCYCODE</a>.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:TaxCurrencyTaxAmount</code></p></td>
@@ -9212,7 +9070,7 @@ Tax amount in tax currency per subtotal.</p></td>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:TaxCurrencyTaxAmount/@currencyID</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Tax currency tax amount currency</strong><br>
-Currency of tax amount in tax currency per subtotal.</p></td>
+For valid values see code list <a href="https://pagero.github.io/puf-code-lists/#_puf_004_currencycode" target="_blank" rel="noopener">PUF-004-CURRENCYCODE</a>.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:TaxInclusiveAmount</code></p></td>
@@ -9238,6 +9096,21 @@ For valid values see code list <a href="https://pagero.github.io/puf-code-lists/
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:TaxChargeability/cbc:TaxTypeCode</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Tax chargeability</strong><br>
 Tax chargeability per tax (see Italy section <a href="#_tax_chargeability_esigibilita_iva">here</a>).</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:EquivalenceSurcharge/cbc:Percent</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Equivalence surcharge percentage</strong><br>
+The percentage rate of the equivalence surcharge (Recargo de Equivalencia). Used in Spain for certain retail traders.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:EquivalenceSurcharge/puf:Amount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Equivalence surcharge amount</strong><br>
+The amount of the equivalence surcharge (Recargo de Equivalencia). Used in Spain for certain retail traders.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:EquivalenceSurcharge/puf:Amount/@currencyID</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Currency of EquivalenceSurcharge Amount</strong><br>
+For valid values see code list <a href="https://pagero.github.io/puf-code-lists/#_puf_004_currencycode" target="_blank" rel="noopener">PUF-004-CURRENCYCODE</a>.</p></td>
 </tr>
 </tbody>
 </table>
@@ -9357,9 +9230,186 @@ Tax chargeability per tax (see Italy section <a href="#_tax_chargeability_esigib
 </table>
 </div>
 </div>
+<div class="sect4">
+<h5 id="_special_regime_key"><a class="anchor" href="#_special_regime_key"></a><a class="link" href="#_special_regime_key">Special regime key</a></h5>
+<div class="paragraph">
+<p>Some countries require a special regime key to classify the tax regime type or special transaction scheme. This is mandatory in certain jurisdictions (e.g., Spain VeriFactu).</p>
+</div>
+<div class="paragraph">
+<p>The special regime key is provided using <code>puf:SpecialRegimeKey</code> within the <code>TaxSubtotalExtension</code>.</p>
+</div>
+<div class="paragraph">
+<p>For a complete list of special regime keys, see <a href="https://pagero.github.io/puf-code-lists/#_puf_022_specialregimekey" target="_blank" rel="noopener">PUF-022-SPECIALREGIMEKEY</a>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Example</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
+  <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+  <span class="tag">&lt;cac:TaxTotal&gt;</span>
+      <span class="tag">&lt;cac:TaxSubtotal&gt;</span>
+          <span class="tag">&lt;ext:UBLExtensions&gt;</span>
+              <span class="tag">&lt;ext:UBLExtension&gt;</span>
+                  <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
+                  <span class="tag">&lt;ext:ExtensionContent&gt;</span>
+                      <span class="tag">&lt;puf:PageroExtension&gt;</span>
+                          <span class="tag">&lt;puf:TaxSubtotalExtension&gt;</span>
+                              <span class="tag">&lt;puf:SpecialRegimeKey&gt;</span>01<span class="tag">&lt;/puf:SpecialRegimeKey&gt;</span> <i class="conum" data-value="1"></i><b>(1)</b>
+                          <span class="tag">&lt;/puf:TaxSubtotalExtension&gt;</span>
+                      <span class="tag">&lt;/puf:PageroExtension&gt;</span>
+                  <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
+              <span class="tag">&lt;/ext:UBLExtension&gt;</span>
+          <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+          <span class="tag">&lt;cbc:TaxableAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>1000.00<span class="tag">&lt;/cbc:TaxableAmount&gt;</span>
+          <span class="tag">&lt;cbc:TaxAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>210.00<span class="tag">&lt;/cbc:TaxAmount&gt;</span>
+          <span class="tag">&lt;cac:TaxCategory&gt;</span>
+              <span class="tag">&lt;cbc:ID&gt;</span>S<span class="tag">&lt;/cbc:ID&gt;</span>
+              <span class="tag">&lt;cbc:Percent&gt;</span>21.0<span class="tag">&lt;/cbc:Percent&gt;</span>
+              <span class="tag">&lt;cac:TaxScheme&gt;</span>
+                  <span class="tag">&lt;cbc:ID&gt;</span>VAT<span class="tag">&lt;/cbc:ID&gt;</span>
+              <span class="tag">&lt;/cac:TaxScheme&gt;</span>
+          <span class="tag">&lt;/cac:TaxCategory&gt;</span>
+      <span class="tag">&lt;/cac:TaxSubtotal&gt;</span>
+  <span class="tag">&lt;/cac:TaxTotal&gt;</span>
+  <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+<span class="tag">&lt;/Invoice&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Special regime key code (e.g., <code>01</code> for general regime in Spain).</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_equivalence_surcharge"><a class="anchor" href="#_equivalence_surcharge"></a><a class="link" href="#_equivalence_surcharge">Equivalence surcharge</a></h5>
+<div class="paragraph">
+<p>The equivalence surcharge (Recargo de Equivalencia) is a special tax regime applicable to certain retail traders in Spain. When applicable, both the rate and amount must be provided.</p>
+</div>
+<div class="paragraph">
+<p><strong>Example</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
+  <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+  <span class="tag">&lt;cac:TaxTotal&gt;</span>
+      <span class="tag">&lt;cac:TaxSubtotal&gt;</span>
+          <span class="tag">&lt;ext:UBLExtensions&gt;</span>
+              <span class="tag">&lt;ext:UBLExtension&gt;</span>
+                  <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
+                  <span class="tag">&lt;ext:ExtensionContent&gt;</span>
+                      <span class="tag">&lt;puf:PageroExtension&gt;</span>
+                          <span class="tag">&lt;puf:TaxSubtotalExtension&gt;</span>
+                              <span class="tag">&lt;puf:SpecialRegimeKey&gt;</span>18<span class="tag">&lt;/puf:SpecialRegimeKey&gt;</span> <i class="conum" data-value="1"></i><b>(1)</b>
+                              <span class="tag">&lt;puf:EquivalenceSurcharge&gt;</span>
+                                  <span class="tag">&lt;cbc:Percent&gt;</span>5.2<span class="tag">&lt;/cbc:Percent&gt;</span> <i class="conum" data-value="2"></i><b>(2)</b>
+                                  <span class="tag">&lt;puf:Amount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>52.00<span class="tag">&lt;/puf:Amount&gt;</span> <i class="conum" data-value="3"></i><b>(3)</b>
+                              <span class="tag">&lt;/puf:EquivalenceSurcharge&gt;</span>
+                          <span class="tag">&lt;/puf:TaxSubtotalExtension&gt;</span>
+                      <span class="tag">&lt;/puf:PageroExtension&gt;</span>
+                  <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
+              <span class="tag">&lt;/ext:UBLExtension&gt;</span>
+          <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+          <span class="tag">&lt;cbc:TaxableAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>1000.00<span class="tag">&lt;/cbc:TaxableAmount&gt;</span>
+          <span class="tag">&lt;cbc:TaxAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>210.00<span class="tag">&lt;/cbc:TaxAmount&gt;</span> <i class="conum" data-value="4"></i><b>(4)</b>
+          <span class="tag">&lt;cac:TaxCategory&gt;</span>
+              <span class="tag">&lt;cbc:ID&gt;</span>S<span class="tag">&lt;/cbc:ID&gt;</span>
+              <span class="tag">&lt;cbc:Percent&gt;</span>21.0<span class="tag">&lt;/cbc:Percent&gt;</span>
+              <span class="tag">&lt;cac:TaxScheme&gt;</span>
+                  <span class="tag">&lt;cbc:ID&gt;</span>VAT<span class="tag">&lt;/cbc:ID&gt;</span>
+              <span class="tag">&lt;/cac:TaxScheme&gt;</span>
+          <span class="tag">&lt;/cac:TaxCategory&gt;</span>
+      <span class="tag">&lt;/cac:TaxSubtotal&gt;</span>
+  <span class="tag">&lt;/cac:TaxTotal&gt;</span>
+  <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+<span class="tag">&lt;/Invoice&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Special regime key <code>18</code> indicates equivalence surcharge applies.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Equivalence surcharge rate (5.2%).</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Equivalence surcharge amount = 1000.00 × 5.2% = 52.00.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>Tax amount (IVA) = 1000.00 × 21% = 210.00.</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_tax_base_at_cost"><a class="anchor" href="#_tax_base_at_cost"></a><a class="link" href="#_tax_base_at_cost">Tax base at cost</a></h5>
+<div class="paragraph">
+<p>For special group regimes in certain countries (e.g., Spain), a tax base at cost may be required in addition to the standard taxable amount.</p>
+</div>
+<div class="paragraph">
+<p><strong>Example</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
+  <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+  <span class="tag">&lt;cac:TaxTotal&gt;</span>
+      <span class="tag">&lt;cac:TaxSubtotal&gt;</span>
+          <span class="tag">&lt;ext:UBLExtensions&gt;</span>
+              <span class="tag">&lt;ext:UBLExtension&gt;</span>
+                  <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
+                  <span class="tag">&lt;ext:ExtensionContent&gt;</span>
+                      <span class="tag">&lt;puf:PageroExtension&gt;</span>
+                          <span class="tag">&lt;puf:TaxSubtotalExtension&gt;</span>
+                              <span class="tag">&lt;puf:SpecialRegimeKey&gt;</span>06<span class="tag">&lt;/puf:SpecialRegimeKey&gt;</span> <i class="conum" data-value="1"></i><b>(1)</b>
+                              <span class="tag">&lt;puf:TaxBaseAtCost</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>800.00<span class="tag">&lt;/puf:TaxBaseAtCost&gt;</span> <i class="conum" data-value="2"></i><b>(2)</b>
+                          <span class="tag">&lt;/puf:TaxSubtotalExtension&gt;</span>
+                      <span class="tag">&lt;/puf:PageroExtension&gt;</span>
+                  <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
+              <span class="tag">&lt;/ext:UBLExtension&gt;</span>
+          <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+          <span class="tag">&lt;cbc:TaxableAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>1000.00<span class="tag">&lt;/cbc:TaxableAmount&gt;</span>
+          <span class="tag">&lt;cbc:TaxAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>210.00<span class="tag">&lt;/cbc:TaxAmount&gt;</span>
+          <span class="tag">&lt;cac:TaxCategory&gt;</span>
+              <span class="tag">&lt;cbc:ID&gt;</span>S<span class="tag">&lt;/cbc:ID&gt;</span>
+              <span class="tag">&lt;cbc:Percent&gt;</span>21.0<span class="tag">&lt;/cbc:Percent&gt;</span>
+              <span class="tag">&lt;cac:TaxScheme&gt;</span>
+                  <span class="tag">&lt;cbc:ID&gt;</span>VAT<span class="tag">&lt;/cbc:ID&gt;</span>
+              <span class="tag">&lt;/cac:TaxScheme&gt;</span>
+          <span class="tag">&lt;/cac:TaxCategory&gt;</span>
+      <span class="tag">&lt;/cac:TaxSubtotal&gt;</span>
+  <span class="tag">&lt;/cac:TaxTotal&gt;</span>
+  <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+<span class="tag">&lt;/Invoice&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Special regime key <code>06</code> - VAT group advanced level.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Tax base calculated at cost for the special group regime.</td>
+</tr>
+</table>
+</div>
+</div>
 </div>
 <div class="sect3">
-<h4 id="_legalmonetarytotal"><a class="anchor" href="#_legalmonetarytotal"></a><a class="link" href="#_legalmonetarytotal">4.1.21. LegalMonetaryTotal</a></h4>
+<h4 id="_legalmonetarytotal"><a class="anchor" href="#_legalmonetarytotal"></a><a class="link" href="#_legalmonetarytotal">4.1.20. LegalMonetaryTotal</a></h4>
 <div class="paragraph">
 <p>The UBL extension to be used for below elements can be found <a href="#_caclegalmonetarytotal">here</a>.</p>
 </div>
@@ -9409,7 +9459,7 @@ Tax chargeability per tax (see Italy section <a href="#_tax_chargeability_esigib
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 58. Elements added in puf:LegalMonetaryTotalExtension</caption>
+<caption class="title">Table 57. Elements added in puf:LegalMonetaryTotalExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -9632,6 +9682,311 @@ Please note that tax has been excluded in above example.
 </div>
 </div>
 </div>
+<div class="sect3">
+<h4 id="_prepaidpayment"><a class="anchor" href="#_prepaidpayment"></a><a class="link" href="#_prepaidpayment">4.1.21. PrepaidPayment</a></h4>
+<div class="paragraph">
+<p>The UBL extension to be used for below elements can be found <a href="#_cacprepaidpayment">here</a>.</p>
+</div>
+<div class="paragraph">
+<p>The structure used from <code>PUF-ExtensionComponent.xsd</code> is <code>puf:PageroExtension/puf:PrepaidPaymentExtension</code>.</p>
+</div>
+<div class="paragraph">
+<p>See example below as well as the URI to be used for this extension.</p>
+</div>
+<div class="paragraph">
+<p><strong>Example</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
+<span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+    <span class="tag">&lt;cac:PrepaidPayment&gt;</span>
+            <span class="tag">&lt;ext:UBLExtensions&gt;</span>
+                <span class="tag">&lt;ext:UBLExtension&gt;</span>
+                    <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:PrepaidPaymentExtension<span class="tag">&lt;/ext:ExtensionURI&gt;</span> <i class="conum" data-value="1"></i><b>(1)</b>
+                        <span class="tag">&lt;ext:ExtensionContent&gt;</span>
+                            <span class="tag">&lt;puf:PageroExtension&gt;</span>
+                                <span class="tag">&lt;puf:PrepaidPaymentExtension</span><span class="tag">/&gt;</span> <i class="conum" data-value="2"></i><b>(2)</b>
+                        <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
+                <span class="tag">&lt;/ext:UBLExtension&gt;</span>
+            <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+    <span class="tag">&lt;/cac:PrepaidPayment&gt;</span>
+<span class="tag">&lt;/Invoice&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>URI to be used if this extension is added.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Structure to be used if information from this extension will be used.</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>Below table shows the definition of the extended element.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 58. Elements added in puf:PrepaidPaymentExtension</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Element</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:DocumentReference/cbc:ID</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Prepayment invoice number ID</strong><br>
+The invoice number of the associated prepayment invoice.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:DocumentReference/cbc:IssueDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Prepayment invoice issue date</strong><br>
+Issue date of associated prepayment invoice.<br>
+<em>Format "YYYY-MM-DD". of the associated prepayment invoice.</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:DocumentReference/cbc:IssueTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Prepayment invoice issue time</strong><br>
+Issue time of associated prepayment invoice.<br>
+<em>Format "HH:mm:ss", "HH:mm:ssZZZZ", "HH:mm:ss.SSS’Z'", or "HH:mm:ss.SSS".</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:DocumentReference/cbc:DocumentTypeCode</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Document type code</strong><br>
+Document type code should be '386' when referencing a prepayment invoice.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cbc:Description</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Name/Description of the prepayment</strong><br>
+Description of the prepayment (free text).</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:TaxTotal/cbc:TaxAmount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Total tax amount</strong><br>
+Prepayment invoice total tax amount in document currency.<br>
+<em>Summary of all cac:TaxSubTotal/cbc:TaxAmount of the prepayment.</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:TaxTotal/cbc:TaxAmount/@currencyID</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Total tax amount currency</strong><br>
+Prepayment invoice total tax amount currency, must be the same as <code>cbc:DocumentCurrencyCode</code>.<br>
+For valid values see code list <a href="https://pagero.github.io/puf-code-lists/#_puf_004_currencycode" target="_blank" rel="noopener">PUF-004-CURRENCYCODE</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:TaxTotal/cac:TaxSubtotal/cbc:TaxableAmount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Total taxable amount for each tax category</strong><br>
+Total taxable amount for each tax category or tax rate.<br>
+<em>E.g. Summary of all taxable amounts for invoice lines with a certain tax percent.</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:TaxSubtotal/cbc:TaxableAmount/@currencyID</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Total taxable amount for each tax category currency</strong><br>
+Total taxable amount currency, must be the same as <code>cbc:DocumentCurrencyCode</code>.<br>
+For valid values see code list <a href="https://pagero.github.io/puf-code-lists/#_puf_004_currencycode" target="_blank" rel="noopener">PUF-004-CURRENCYCODE</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:TaxSubtotal/cbc:TaxAmount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Total tax amount for each tax category</strong><br>
+Total tax amount for a certain tax category or tax rate.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:TaxSubtotal/cbc:TaxAmount/@currencyID</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Total tax amount currency for each tax category</strong><br>
+Total tax amount currency, must be the same as <code>cbc:DocumentCurrencyCode</code>.<br>
+For valid values see code list <a href="https://pagero.github.io/puf-code-lists/#_puf_004_currencycode" target="_blank" rel="noopener">PUF-004-CURRENCYCODE</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:TaxSubtotal/cac:TaxCategory/cbc:ID</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Tax category code</strong><br>
+Code for identifying the tax category.<br>
+<em>E.g. tax category "S".</em><br>
+For valid values see code list <a href="https://pagero.github.io/puf-code-lists/#_puf_012_taxcategorycode" target="_blank" rel="noopener">PUF-012-TAXCATEGORYCODE</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:TaxSubtotal/cac:TaxCategory/cbc:Percent</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Tax category percent</strong><br>
+Percentage rate for the tax category.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:TaxSubtotal/cac:TaxCategory/cbc:TaxExemptionReasonCode</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Tax exemption reason code</strong><br>
+Exemption reason code for the tax category, only applicable if the goods or service is exempt from tax.<br>
+See code list <a href="https://pagero.github.io/puf-code-lists/#_puf_013_taxexemptioncode" target="_blank" rel="noopener">PUF-013-TAXEXEMPTIONCODE</a> for recommendations.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:TaxSubtotal/cac:TaxCategory/cbc:TaxExemptionReason</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Tax exemption reason</strong><br>
+Exemption reason for the tax category, only applicable if the goods or service is exempt from tax.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:TaxSubtotal/cac:TaxCategory/cac:TaxScheme/cbc:ID</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Tax scheme identfier</strong><br>
+Tax scheme for the tax category.<br>
+For valid values see code list <a href="https://pagero.github.io/puf-code-lists/#_puf_009_taxtypescheme" target="_blank" rel="noopener">PUF-009-TAXTYPESCHEME</a>.</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p><strong>Example</strong><br>
+<em>cac:PrepaidPayment example</em></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
+  <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+  <span class="tag">&lt;cac:PrepaidPayment&gt;</span>
+        <span class="tag">&lt;ext:UBLExtensions&gt;</span>
+            <span class="tag">&lt;ext:UBLExtension&gt;</span>
+                <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:PrepaidPaymentExtension<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
+                    <span class="tag">&lt;ext:ExtensionContent&gt;</span>
+                        <span class="tag">&lt;puf:PageroExtension&gt;</span>
+                            <span class="tag">&lt;puf:PrepaidPaymentExtension&gt;</span>
+                                <span class="tag">&lt;cac:DocumentReference&gt;</span>
+                                    <span class="tag">&lt;cbc:ID&gt;</span>46531<span class="tag">&lt;/cbc:ID&gt;</span>
+                                    <span class="tag">&lt;cbc:IssueDate&gt;</span>2021-07-31<span class="tag">&lt;/cbc:IssueDate&gt;</span>
+                                    <span class="tag">&lt;cbc:IssueTime&gt;</span>12:28:17<span class="tag">&lt;/cbc:IssueTime&gt;</span>
+                                    <span class="tag">&lt;cbc:DocumentTypeCode&gt;</span>386<span class="tag">&lt;/cbc:DocumentTypeCode&gt;</span>
+                                <span class="tag">&lt;/cac:DocumentReference&gt;</span>
+                                <span class="tag">&lt;cbc:Description&gt;</span>Prepayment adjustment<span class="tag">&lt;/cbc:Description&gt;</span>
+                                <span class="tag">&lt;cac:TaxTotal&gt;</span>
+                                    <span class="tag">&lt;cbc:TaxAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">SAR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>1.50<span class="tag">&lt;/cbc:TaxAmount&gt;</span>
+                                    <span class="tag">&lt;cac:TaxSubtotal&gt;</span>
+                                        <span class="tag">&lt;cbc:TaxableAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">SAR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>10.00<span class="tag">&lt;/cbc:TaxableAmount&gt;</span>
+                                        <span class="tag">&lt;cbc:TaxAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">SAR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>1.50<span class="tag">&lt;/cbc:TaxAmount&gt;</span>
+                                        <span class="tag">&lt;cac:TaxCategory&gt;</span>
+                                            <span class="tag">&lt;cbc:ID&gt;</span>S<span class="tag">&lt;/cbc:ID&gt;</span>
+                                            <span class="tag">&lt;cbc:Percent&gt;</span>15.00<span class="tag">&lt;/cbc:Percent&gt;</span>
+                                            <span class="tag">&lt;cac:TaxScheme&gt;</span>
+                                                <span class="tag">&lt;cbc:ID&gt;</span>VAT<span class="tag">&lt;/cbc:ID&gt;</span>
+                                            <span class="tag">&lt;/cac:TaxScheme&gt;</span>
+                                        <span class="tag">&lt;/cac:TaxCategory&gt;</span>
+                                    <span class="tag">&lt;/cac:TaxSubtotal&gt;</span>
+                                <span class="tag">&lt;/cac:TaxTotal&gt;</span>
+                            <span class="tag">&lt;/puf:PrepaidPaymentExtension&gt;</span>
+                        <span class="tag">&lt;/puf:PageroExtension&gt;</span>
+                    <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
+            <span class="tag">&lt;/ext:UBLExtension&gt;</span>
+        <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+        <span class="tag">&lt;cbc:PaidAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">SAR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>11.50<span class="tag">&lt;/cbc:PaidAmount&gt;</span>
+    <span class="tag">&lt;/cac:PrepaidPayment&gt;</span>
+  <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+<span class="tag">&lt;/Invoice&gt;</span></code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_languagecode"><a class="anchor" href="#_languagecode"></a><a class="link" href="#_languagecode">4.1.22. LanguageCode</a></h4>
+<div class="paragraph">
+<p>In order to specify language code for the system generated PDF presentation in Pagero Online, a segment for this is added as Extension.</p>
+</div>
+<div class="admonitionblock warning">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-warning" title="Warning"></i>
+</td>
+<td class="content">
+Note that not all languages are supported in Pagero Online.<br>
+Please contact us to learn which languages are available.
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>The UBL extension to be used for below elements can be found <a href="#_extublextensions">here</a>.</p>
+</div>
+<div class="paragraph">
+<p>The structure used from <code>PUF-ExtensionComponent.xsd</code> is <code>PageroExtension/LanguageCode</code>.</p>
+</div>
+<div class="paragraph">
+<p>See example below as well as the URI to be used for this extension.</p>
+</div>
+<div class="paragraph">
+<p><strong>Example</strong><br></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
+  <span class="tag">&lt;ext:UBLExtensions&gt;</span>
+      <span class="tag">&lt;ext:UBLExtension&gt;</span>
+          <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:LanguageCode<span class="tag">&lt;/ext:ExtensionURI&gt;</span> <i class="conum" data-value="1"></i><b>(1)</b>
+          <span class="tag">&lt;ext:ExtensionContent&gt;</span>
+              <span class="tag">&lt;puf:PageroExtension&gt;</span>
+                <span class="tag">&lt;puf:LanguageCode</span><span class="tag">/&gt;</span> <i class="conum" data-value="2"></i><b>(2)</b>
+              <span class="tag">&lt;/puf:PageroExtension&gt;</span>
+          <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
+      <span class="tag">&lt;/ext:UBLExtension&gt;</span>
+  <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+  <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+<span class="tag">&lt;/Invoice&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>URI to be used if this extension is added.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Structure to be used if information from this extension will be used.</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>Below table shows the definition of the new elements added to the extension.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 59. Elements added to puf:PageroExtension/puf:LanguageCode</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Element</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:LanguageCode</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Language Code</strong><br>
+Must be in lower case alpha, ISO 639-1, format.</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p><strong>Example</strong><br>
+<em>Language Code</em></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
+    <span class="tag">&lt;ext:UBLExtensions&gt;</span>
+        <span class="tag">&lt;ext:UBLExtension&gt;</span>
+            <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:LanguageCode<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
+            <span class="tag">&lt;ext:ExtensionContent&gt;</span>
+                <span class="tag">&lt;puf:PageroExtension&gt;</span>
+                    <span class="tag">&lt;puf:LanguageCode&gt;</span>en<span class="tag">&lt;/puf:LanguageCode&gt;</span>
+                <span class="tag">&lt;/puf:PageroExtension&gt;</span>
+            <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
+        <span class="tag">&lt;/ext:UBLExtension&gt;</span>
+    <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+<span class="tag">&lt;/Invoice&gt;</span></code></pre>
+</div>
+</div>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_line_level"><a class="anchor" href="#_line_level"></a><a class="link" href="#_line_level">4.2. Line level</a></h3>
@@ -9707,7 +10062,7 @@ If country specific information is available as restricted information value, th
 <p>Below table show the definition of the new element added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 59. Elements added in puf:RestrictedInformation</caption>
+<caption class="title">Table 60. Elements added in puf:RestrictedInformation</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -9816,7 +10171,7 @@ Value relevant to the assigned key.</p></td>
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 60. Elements added to puf:LineExtension</caption>
+<caption class="title">Table 61. Elements added to puf:LineExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -9936,7 +10291,7 @@ For valid values see code list <a href="https://pagero.github.io/puf-code-lists/
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 61. Elements added to puf:LineExtension</caption>
+<caption class="title">Table 62. Elements added to puf:LineExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -10059,7 +10414,7 @@ For valid values see code list <a href="https://pagero.github.io/puf-code-lists/
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 62. Elements added to puf:LineExtension</caption>
+<caption class="title">Table 63. Elements added to puf:LineExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -10179,7 +10534,7 @@ For valid values see code list <a href="https://pagero.github.io/puf-code-lists/
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 63. Elements added to puf:LineExtension</caption>
+<caption class="title">Table 64. Elements added to puf:LineExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -10305,7 +10660,7 @@ For valid values see code list <a href="https://pagero.github.io/puf-code-lists/
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 64. Elements added to puf:LineExtension/puf:OriginatorDocumentReference</caption>
+<caption class="title">Table 65. Elements added to puf:LineExtension/puf:OriginatorDocumentReference</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -10416,7 +10771,7 @@ Date of issue of the referenced tender, date should be formatted "yyyy-mm-dd".</
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 65. Elements added to puf:LineExtension/puf:ProjectReference</caption>
+<caption class="title">Table 66. Elements added to puf:LineExtension/puf:ProjectReference</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -10527,7 +10882,7 @@ Identification of the project reference.</p></td>
 <p>Below table show the definition of the new element added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 66. Elements added in puf:OrderLineReference</caption>
+<caption class="title">Table 67. Elements added in puf:OrderLineReference</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -10641,7 +10996,7 @@ Date of the sales order, date should be formatted "yyyy-mm-dd".</p></td>
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 67. Elements added to puf:LineExtension/puf:ContractDocumentReference</caption>
+<caption class="title">Table 68. Elements added to puf:LineExtension/puf:ContractDocumentReference</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -10762,7 +11117,7 @@ Issue date for the buyer referenced contract document, date should be formatted 
 <p>Below table show the definition of the new element added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 68. Elements added to puf:ItemExtension</caption>
+<caption class="title">Table 69. Elements added to puf:ItemExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -10867,7 +11222,7 @@ Type of item, valid values are <code>GOODS</code> or <code>SERVICE</code>.</p></
 <p>Below table show the definition of the new element added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 69. Elements added to puf:PriceExtension</caption>
+<caption class="title">Table 70. Elements added to puf:PriceExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -13868,12 +14223,858 @@ can be provided. Note that in this scenario the QR string must be sent as plain 
 </div>
 </div>
 <div class="sect2">
-<h3 id="_türkiye"><a class="anchor" href="#_türkiye"></a><a class="link" href="#_türkiye">5.16. Türkiye</a></h3>
+<h3 id="_spain_verifactu"><a class="anchor" href="#_spain_verifactu"></a><a class="link" href="#_spain_verifactu">5.16. Spain VeriFactu</a></h3>
+<div class="paragraph">
+<p>This section contains information about requirements and other information concerning VeriFactu e-invoicing in Spain.</p>
+</div>
+<div class="sect3">
+<h4 id="_invoice_number_and_invoice_series"><a class="anchor" href="#_invoice_number_and_invoice_series"></a><a class="link" href="#_invoice_number_and_invoice_series">5.16.1. Invoice Number and Invoice Series</a></h4>
+<div class="paragraph">
+<p>VeriFactu requires both an invoice number and an invoice series to uniquely identify invoices.</p>
+</div>
+<div class="paragraph">
+<p>The invoice number is provided in the standard <code>cbc:ID</code> element.</p>
+</div>
+<div class="paragraph">
+<p>The invoice series must be provided using a PUF extension:</p>
+</div>
+<div class="paragraph">
+<p><strong>Example</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
+    <span class="tag">&lt;ext:UBLExtensions&gt;</span>
+        <span class="tag">&lt;ext:UBLExtension&gt;</span>
+            <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:InvoiceSeries<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
+            <span class="tag">&lt;ext:ExtensionContent&gt;</span>
+                <span class="tag">&lt;puf:PageroExtension&gt;</span>
+                    <span class="tag">&lt;puf:InvoiceSeries&gt;</span>
+                        <span class="tag">&lt;cbc:ID&gt;</span>2025-A<span class="tag">&lt;/cbc:ID&gt;</span>
+                    <span class="tag">&lt;/puf:InvoiceSeries&gt;</span>
+                <span class="tag">&lt;/puf:PageroExtension&gt;</span>
+            <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
+        <span class="tag">&lt;/ext:UBLExtension&gt;</span>
+    <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+    <span class="tag">&lt;cbc:ID&gt;</span>001<span class="tag">&lt;/cbc:ID&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+<span class="tag">&lt;/Invoice&gt;</span></code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_document_type_specification"><a class="anchor" href="#_document_type_specification"></a><a class="link" href="#_document_type_specification">5.16.2. Document Type Specification</a></h4>
+<div class="paragraph">
+<p>VeriFactu distinguishes between different document types including standard invoices, simplified invoices, and corrective invoices. The document type is specified using the <code>cbc:InvoiceTypeCode</code> element with an additional <code>@name</code> attribute containing the Spanish invoice type identifier (F1-F3 for invoices, R1-R5 for rectifications).</p>
+</div>
+<div class="paragraph">
+<p>See <a href="https://pagero.github.io/puf-code-lists/#_invoice_type_codes_for_spain_verifactu" target="_blank" rel="noopener">PUF-003-INVOICETYPECODE (Spain VeriFactu)</a> for the complete list of invoice type codes.</p>
+</div>
+<div class="sect4">
+<h5 id="_standard_invoices"><a class="anchor" href="#_standard_invoices"></a><a class="link" href="#_standard_invoices">Standard Invoices</a></h5>
+<div class="paragraph">
+<p><strong>Standard Invoice (F1)</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
+    <span class="tag">&lt;cbc:InvoiceTypeCode</span> <span class="attribute-name">name</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">F1</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>380<span class="tag">&lt;/cbc:InvoiceTypeCode&gt;</span><i class="conum" data-value="1"></i><b>(1)</b>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+<span class="tag">&lt;/Invoice&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>F1 - Factura (art. 6, 7.2 y 7.3 del RD 1619/2012)</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><strong>Simplified Invoice (F2)</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
+    <span class="tag">&lt;cbc:InvoiceTypeCode</span> <span class="attribute-name">name</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">F2</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>380<span class="tag">&lt;/cbc:InvoiceTypeCode&gt;</span><i class="conum" data-value="1"></i><b>(1)</b>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+<span class="tag">&lt;/Invoice&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>F2 - Factura Simplificada y Facturas sin identificación del destinatario art. 6.1.d) RD 1619/2012</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_corrective_invoices"><a class="anchor" href="#_corrective_invoices"></a><a class="link" href="#_corrective_invoices">Corrective Invoices</a></h5>
+<div class="paragraph">
+<p>Corrective invoices can be issued using either Invoice (type code 384) or CreditNote (type code 381) depending on the business scenario.</p>
+</div>
+<div class="paragraph">
+<p><strong>Corrective Invoice - Legal Error (R1)</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
+    <span class="tag">&lt;cbc:InvoiceTypeCode</span> <span class="attribute-name">name</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">R1</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>384<span class="tag">&lt;/cbc:InvoiceTypeCode&gt;</span><i class="conum" data-value="1"></i><b>(1)</b>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+<span class="tag">&lt;/Invoice&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>R1 - Factura Rectificativa (Error fundado en derecho y Art. 80 Uno Dos y Seis LIVA)</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><strong>Credit Note - Legal Error (R1)</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;CreditNote&gt;</span>
+    <span class="tag">&lt;cbc:CreditNoteTypeCode</span> <span class="attribute-name">name</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">R1</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>381<span class="tag">&lt;/cbc:CreditNoteTypeCode&gt;</span><i class="conum" data-value="1"></i><b>(1)</b>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+<span class="tag">&lt;/CreditNote&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>R1 - Factura Rectificativa (Error fundado en derecho y Art. 80 Uno Dos y Seis LIVA)</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_simplified_invoice_indicator"><a class="anchor" href="#_simplified_invoice_indicator"></a><a class="link" href="#_simplified_invoice_indicator">5.16.3. Simplified Invoice Indicator</a></h4>
+<div class="paragraph">
+<p>VeriFactu separates the legal invoice type (F1/F2/F3, R1-R5) from the Article 7.2/7.3 simplified qualifier. Use <code>cbc:InvoiceTypeCode/@name</code> for the invoice type (e.g. F2) and only include the <code>puf:Simplified</code> extension when the invoice meets the specific Article 7.2/7.3 conditions. For other types it must be omitted. If omitted on an F2 invoice, the default is false.</p>
+</div>
+<div class="paragraph">
+<p><strong>Example</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+    <span class="tag">&lt;ext:UBLExtensions&gt;</span>
+        <span class="tag">&lt;ext:UBLExtension&gt;</span>
+            <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:Simplified<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
+            <span class="tag">&lt;ext:ExtensionContent&gt;</span>
+                <span class="tag">&lt;puf:PageroExtension&gt;</span>
+                    <span class="tag">&lt;puf:Simplified&gt;</span>true<span class="tag">&lt;/puf:Simplified&gt;</span><i class="conum" data-value="1"></i><b>(1)</b>
+                <span class="tag">&lt;/puf:PageroExtension&gt;</span>
+            <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
+        <span class="tag">&lt;/ext:UBLExtension&gt;</span>
+    <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+<span class="tag">&lt;/Invoice&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Supported values: <code>true</code> (yes) or <code>false</code> (no - default if not provided)</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_correction_information"><a class="anchor" href="#_correction_information"></a><a class="link" href="#_correction_information">5.16.4. Correction Information</a></h4>
+<div class="paragraph">
+<p>When issuing corrective invoices (credit notes or corrections), VeriFactu requires specific information about the original invoice being corrected.</p>
+</div>
+<div class="sect4">
+<h5 id="_correction_type"><a class="anchor" href="#_correction_type"></a><a class="link" href="#_correction_type">Correction Type</a></h5>
+<div class="paragraph">
+<p>Spain VeriFactu requires specifying the correction method:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>I</code> - Correction by differences (corrección por diferencias)</p>
+</li>
+<li>
+<p><code>S</code> - Substitutive method (método sustitutivo)</p>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_billing_reference_structure"><a class="anchor" href="#_billing_reference_structure"></a><a class="link" href="#_billing_reference_structure">Billing Reference Structure</a></h5>
+<div class="paragraph">
+<p>The correction information is provided in the <code>cac:BillingReference</code> section with PUF extensions:</p>
+</div>
+<div class="paragraph">
+<p><strong>Example - Correction by Differences</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
+    <span class="tag">&lt;cbc:InvoiceTypeCode&gt;</span>384<span class="tag">&lt;/cbc:InvoiceTypeCode&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+    <span class="tag">&lt;cac:BillingReference&gt;</span>
+        <span class="tag">&lt;cac:InvoiceDocumentReference&gt;</span>
+            <span class="tag">&lt;cbc:ID&gt;</span>001<span class="tag">&lt;/cbc:ID&gt;</span><i class="conum" data-value="1"></i><b>(1)</b>
+            <span class="tag">&lt;cbc:IssueDate&gt;</span>2025-01-15<span class="tag">&lt;/cbc:IssueDate&gt;</span><i class="conum" data-value="2"></i><b>(2)</b>
+            <span class="tag">&lt;ext:UBLExtensions&gt;</span>
+                <span class="tag">&lt;ext:UBLExtension&gt;</span>
+                    <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:BillingReferenceExtension<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
+                    <span class="tag">&lt;ext:ExtensionContent&gt;</span>
+                        <span class="tag">&lt;puf:PageroExtension&gt;</span>
+                            <span class="tag">&lt;puf:BillingReferenceExtension&gt;</span>
+                                <span class="tag">&lt;puf:Code&gt;</span>I<span class="tag">&lt;/puf:Code&gt;</span><i class="conum" data-value="3"></i><b>(3)</b>
+                                <span class="tag">&lt;puf:InvoiceSeries&gt;</span>
+                                    <span class="tag">&lt;cbc:ID&gt;</span>2025-A<span class="tag">&lt;/cbc:ID&gt;</span><i class="conum" data-value="4"></i><b>(4)</b>
+                                <span class="tag">&lt;/puf:InvoiceSeries&gt;</span>
+                            <span class="tag">&lt;/puf:BillingReferenceExtension&gt;</span>
+                        <span class="tag">&lt;/puf:PageroExtension&gt;</span>
+                    <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
+                <span class="tag">&lt;/ext:UBLExtension&gt;</span>
+            <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+        <span class="tag">&lt;/cac:InvoiceDocumentReference&gt;</span>
+    <span class="tag">&lt;/cac:BillingReference&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+<span class="tag">&lt;/Invoice&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Corrected invoice number</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Corrected invoice issue date</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Correction type: <code>I</code> (differences) or <code>S</code> (substitutive)</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>Corrected invoice series</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_substitutive_method_additional_fields"><a class="anchor" href="#_substitutive_method_additional_fields"></a><a class="link" href="#_substitutive_method_additional_fields">Substitutive Method Additional Fields</a></h5>
+<div class="paragraph">
+<p>When using the substitutive method (<code>S</code>), additional fields are mandatory:</p>
+</div>
+<div class="paragraph">
+<p><strong>Example - Substitutive Method</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
+    <span class="tag">&lt;cbc:InvoiceTypeCode&gt;</span>384<span class="tag">&lt;/cbc:InvoiceTypeCode&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+    <span class="tag">&lt;cac:BillingReference&gt;</span>
+        <span class="tag">&lt;cac:InvoiceDocumentReference&gt;</span>
+            <span class="tag">&lt;cbc:ID&gt;</span>001<span class="tag">&lt;/cbc:ID&gt;</span>
+            <span class="tag">&lt;cbc:IssueDate&gt;</span>2025-01-15<span class="tag">&lt;/cbc:IssueDate&gt;</span>
+            <span class="tag">&lt;ext:UBLExtensions&gt;</span>
+                <span class="tag">&lt;ext:UBLExtension&gt;</span>
+                    <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:BillingReferenceExtension<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
+                    <span class="tag">&lt;ext:ExtensionContent&gt;</span>
+                        <span class="tag">&lt;puf:PageroExtension&gt;</span>
+                            <span class="tag">&lt;puf:BillingReferenceExtension&gt;</span>
+                                <span class="tag">&lt;puf:Code&gt;</span>S<span class="tag">&lt;/puf:Code&gt;</span>
+                                <span class="tag">&lt;puf:InvoiceSeries&gt;</span>
+                                    <span class="tag">&lt;cbc:ID&gt;</span>2025-A<span class="tag">&lt;/cbc:ID&gt;</span>
+                                <span class="tag">&lt;/puf:InvoiceSeries&gt;</span>
+                                <span class="tag">&lt;cbc:TaxableAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>1000.00<span class="tag">&lt;/cbc:TaxableAmount&gt;</span><i class="conum" data-value="1"></i><b>(1)</b>
+                                <span class="tag">&lt;cbc:TaxAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>210.00<span class="tag">&lt;/cbc:TaxAmount&gt;</span><i class="conum" data-value="2"></i><b>(2)</b>
+                                <span class="tag">&lt;puf:EquivalenceSurchargeAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>5.00<span class="tag">&lt;/puf:EquivalenceSurchargeAmount&gt;</span><i class="conum" data-value="3"></i><b>(3)</b>
+                            <span class="tag">&lt;/puf:BillingReferenceExtension&gt;</span>
+                        <span class="tag">&lt;/puf:PageroExtension&gt;</span>
+                    <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
+                <span class="tag">&lt;/ext:UBLExtension&gt;</span>
+            <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+        <span class="tag">&lt;/cac:InvoiceDocumentReference&gt;</span>
+    <span class="tag">&lt;/cac:BillingReference&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+<span class="tag">&lt;/Invoice&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Corrected invoice tax base (mandatory for substitutive method)</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Corrected invoice tax amount (mandatory for substitutive method)</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Corrected invoice equivalence surcharge (conditionally mandatory)</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_party_identification_7"><a class="anchor" href="#_party_identification_7"></a><a class="link" href="#_party_identification_7">5.16.5. Party Identification</a></h4>
+<div class="sect4">
+<h5 id="_seller_information"><a class="anchor" href="#_seller_information"></a><a class="link" href="#_seller_information">Seller Information</a></h5>
+<div class="paragraph">
+<p>The seller&#8217;s Spanish Tax Identification Number (NIF) must be provided in the <code>cac:PartyTaxScheme</code> structure:</p>
+</div>
+<div class="paragraph">
+<p><strong>Example</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+    <span class="tag">&lt;cac:AccountingSupplierParty&gt;</span>
+        <span class="tag">&lt;cac:Party&gt;</span>
+            <span class="tag">&lt;cac:PartyTaxScheme&gt;</span>
+                <span class="tag">&lt;cbc:CompanyID&gt;</span>ESB12345678<span class="tag">&lt;/cbc:CompanyID&gt;</span><i class="conum" data-value="1"></i><b>(1)</b>
+                <span class="tag">&lt;cac:TaxScheme&gt;</span>
+                    <span class="tag">&lt;cbc:ID&gt;</span>VAT<span class="tag">&lt;/cbc:ID&gt;</span>
+                <span class="tag">&lt;/cac:TaxScheme&gt;</span>
+            <span class="tag">&lt;/cac:PartyTaxScheme&gt;</span>
+        <span class="tag">&lt;/cac:Party&gt;</span>
+    <span class="tag">&lt;/cac:AccountingSupplierParty&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+<span class="tag">&lt;/Invoice&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Spanish NIF with ES prefix</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_buyer_information"><a class="anchor" href="#_buyer_information"></a><a class="link" href="#_buyer_information">Buyer Information</a></h5>
+<div class="paragraph">
+<p>For the buyer, the VAT number is conditionally mandatory. If the buyer is a Spanish entity, the NIF should be provided. If the buyer does not have a VAT number, an alternative identification must be provided.</p>
+</div>
+<div class="paragraph">
+<p><strong>Example - Buyer with VAT Number</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+    <span class="tag">&lt;cac:AccountingCustomerParty&gt;</span>
+        <span class="tag">&lt;cac:Party&gt;</span>
+            <span class="tag">&lt;cac:PartyTaxScheme&gt;</span>
+                <span class="tag">&lt;cbc:CompanyID&gt;</span>ESB87654321<span class="tag">&lt;/cbc:CompanyID&gt;</span>
+                <span class="tag">&lt;cac:TaxScheme&gt;</span>
+                    <span class="tag">&lt;cbc:ID&gt;</span>VAT<span class="tag">&lt;/cbc:ID&gt;</span>
+                <span class="tag">&lt;/cac:TaxScheme&gt;</span>
+            <span class="tag">&lt;/cac:PartyTaxScheme&gt;</span>
+        <span class="tag">&lt;/cac:Party&gt;</span>
+    <span class="tag">&lt;/cac:AccountingCustomerParty&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+<span class="tag">&lt;/Invoice&gt;</span></code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>Example - Buyer with Alternative Identification</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+    <span class="tag">&lt;cac:AccountingCustomerParty&gt;</span>
+        <span class="tag">&lt;cac:Party&gt;</span>
+            <span class="tag">&lt;cac:PartyIdentification&gt;</span>
+                <span class="tag">&lt;cbc:ID</span> <span class="attribute-name">schemeID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">ES:PASSPORT</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>AB123456<span class="tag">&lt;/cbc:ID&gt;</span><i class="conum" data-value="1"></i><b>(1)</b>
+            <span class="tag">&lt;/cac:PartyIdentification&gt;</span>
+        <span class="tag">&lt;/cac:Party&gt;</span>
+    <span class="tag">&lt;/cac:AccountingCustomerParty&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+<span class="tag">&lt;/Invoice&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Alternative identification using scheme codes from <a href="https://pagero.github.io/puf-code-lists/#_identification_scheme_spain" target="_blank" rel="noopener">PUF-008-IDENTIFICATIONSCHEME</a></td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_tax_details_2"><a class="anchor" href="#_tax_details_2"></a><a class="link" href="#_tax_details_2">5.16.6. Tax Details</a></h4>
+<div class="paragraph">
+<p>Spain VeriFactu requires comprehensive tax information including tax type, tax category, special regime keys, and exemption codes.</p>
+</div>
+<div class="sect4">
+<h5 id="_tax_types"><a class="anchor" href="#_tax_types"></a><a class="link" href="#_tax_types">Tax Types</a></h5>
+<div class="paragraph">
+<p>VeriFactu supports three tax types:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><strong>VAT</strong> (IVA) - Standard Spanish VAT used throughout Spain</p>
+</li>
+<li>
+<p><strong>IGIC</strong> - Special tax for the Canary Islands</p>
+</li>
+<li>
+<p><strong>IPSI</strong> - Special tax for Ceuta and Melilla</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>The tax type is specified in <code>cac:TaxScheme/cbc:ID</code>:</p>
+</div>
+<div class="paragraph">
+<p><strong>Example - IVA (VAT)</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;cac:TaxCategory&gt;</span>
+    <span class="tag">&lt;cbc:ID&gt;</span>S<span class="tag">&lt;/cbc:ID&gt;</span>
+    <span class="tag">&lt;cbc:Percent&gt;</span>21.0<span class="tag">&lt;/cbc:Percent&gt;</span>
+    <span class="tag">&lt;cac:TaxScheme&gt;</span>
+        <span class="tag">&lt;cbc:ID&gt;</span>VAT<span class="tag">&lt;/cbc:ID&gt;</span><i class="conum" data-value="1"></i><b>(1)</b>
+    <span class="tag">&lt;/cac:TaxScheme&gt;</span>
+<span class="tag">&lt;/cac:TaxCategory&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Use <code>VAT</code> for IVA operations</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><strong>Example - IGIC (Canary Islands)</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;cac:TaxCategory&gt;</span>
+    <span class="tag">&lt;cbc:ID&gt;</span>S<span class="tag">&lt;/cbc:ID&gt;</span>
+    <span class="tag">&lt;cbc:Percent&gt;</span>7.0<span class="tag">&lt;/cbc:Percent&gt;</span>
+    <span class="tag">&lt;cac:TaxScheme&gt;</span>
+        <span class="tag">&lt;cbc:ID&gt;</span>IGIC<span class="tag">&lt;/cbc:ID&gt;</span><i class="conum" data-value="1"></i><b>(1)</b>
+    <span class="tag">&lt;/cac:TaxScheme&gt;</span>
+<span class="tag">&lt;/cac:TaxCategory&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Use <code>IGIC</code> for Canary Islands operations</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><strong>Example - IPSI (Ceuta/Melilla)</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;cac:TaxCategory&gt;</span>
+    <span class="tag">&lt;cbc:ID&gt;</span>S<span class="tag">&lt;/cbc:ID&gt;</span>
+    <span class="tag">&lt;cbc:Percent&gt;</span>10.0<span class="tag">&lt;/cbc:Percent&gt;</span>
+    <span class="tag">&lt;cac:TaxScheme&gt;</span>
+        <span class="tag">&lt;cbc:ID&gt;</span>IPSI<span class="tag">&lt;/cbc:ID&gt;</span><i class="conum" data-value="1"></i><b>(1)</b>
+    <span class="tag">&lt;/cac:TaxScheme&gt;</span>
+<span class="tag">&lt;/cac:TaxCategory&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Use <code>IPSI</code> for Ceuta and Melilla operations</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_tax_categories"><a class="anchor" href="#_tax_categories"></a><a class="link" href="#_tax_categories">Tax Categories</a></h5>
+<div class="paragraph">
+<p>VeriFactu uses standard tax category codes from UNCL5305. Common codes include:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><strong>S</strong> - Standard rate</p>
+</li>
+<li>
+<p><strong>AE</strong> - Reverse Charge</p>
+</li>
+<li>
+<p><strong>E</strong> - Exempt from tax</p>
+</li>
+<li>
+<p><strong>O</strong> - Not subject to tax (outside scope)</p>
+</li>
+<li>
+<p><strong>Z</strong> - Zero rated</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>See <a href="https://pagero.github.io/puf-code-lists/#_puf_012_taxcategorycode" target="_blank" rel="noopener">PUF-012-TAXCATEGORYCODE</a> for more details.</p>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_special_regime_keys_claveregimen"><a class="anchor" href="#_special_regime_keys_claveregimen"></a><a class="link" href="#_special_regime_keys_claveregimen">Special Regime Keys (ClaveRegimen)</a></h5>
+<div class="paragraph">
+<p><strong>Mandatory for VeriFactu</strong>: Every tax breakdown must include a Special Regime Key (ClaveRegimen) that identifies the tax regime type or special transaction scheme.</p>
+</div>
+<div class="paragraph">
+<p>The special regime key is provided using a PUF extension within the <code>cac:TaxSubtotal</code> structure. The applicable codes depend on the tax type (VAT/IGIC/IPSI).</p>
+</div>
+<div class="paragraph">
+<p>For a complete list of special regime keys, see <a href="https://pagero.github.io/puf-code-lists/#_puf_022_specialregimekey" target="_blank" rel="noopener">PUF-022-SPECIALREGIMEKEY</a>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Example - IVA General Regime (Code 01)</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;cac:TaxSubtotal&gt;</span>
+    <span class="tag">&lt;ext:UBLExtensions&gt;</span>
+        <span class="tag">&lt;ext:UBLExtension&gt;</span>
+            <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
+            <span class="tag">&lt;ext:ExtensionContent&gt;</span>
+                <span class="tag">&lt;puf:PageroExtension&gt;</span>
+                    <span class="tag">&lt;puf:TaxSubtotalExtension&gt;</span>
+                        <span class="tag">&lt;puf:SpecialRegimeKey&gt;</span>01<span class="tag">&lt;/puf:SpecialRegimeKey&gt;</span><i class="conum" data-value="1"></i><b>(1)</b>
+                    <span class="tag">&lt;/puf:TaxSubtotalExtension&gt;</span>
+                <span class="tag">&lt;/puf:PageroExtension&gt;</span>
+            <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
+        <span class="tag">&lt;/ext:UBLExtension&gt;</span>
+    <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+    <span class="tag">&lt;cbc:TaxableAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>1000.00<span class="tag">&lt;/cbc:TaxableAmount&gt;</span>
+    <span class="tag">&lt;cbc:TaxAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>210.00<span class="tag">&lt;/cbc:TaxAmount&gt;</span>
+    <span class="tag">&lt;cac:TaxCategory&gt;</span>
+        <span class="tag">&lt;cbc:ID&gt;</span>S<span class="tag">&lt;/cbc:ID&gt;</span>
+        <span class="tag">&lt;cbc:Percent&gt;</span>21.0<span class="tag">&lt;/cbc:Percent&gt;</span>
+        <span class="tag">&lt;cac:TaxScheme&gt;</span>
+            <span class="tag">&lt;cbc:ID&gt;</span>VAT<span class="tag">&lt;/cbc:ID&gt;</span>
+        <span class="tag">&lt;/cac:TaxScheme&gt;</span>
+    <span class="tag">&lt;/cac:TaxCategory&gt;</span>
+<span class="tag">&lt;/cac:TaxSubtotal&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Code <code>01</code> - General regime (for IVA operations)</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><strong>Example - Export Operations (Code 02)</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;cac:TaxSubtotal&gt;</span>
+    <span class="tag">&lt;ext:UBLExtensions&gt;</span>
+        <span class="tag">&lt;ext:UBLExtension&gt;</span>
+            <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
+            <span class="tag">&lt;ext:ExtensionContent&gt;</span>
+                <span class="tag">&lt;puf:PageroExtension&gt;</span>
+                    <span class="tag">&lt;puf:TaxSubtotalExtension&gt;</span>
+                        <span class="tag">&lt;puf:SpecialRegimeKey&gt;</span>02<span class="tag">&lt;/puf:SpecialRegimeKey&gt;</span><i class="conum" data-value="1"></i><b>(1)</b>
+                    <span class="tag">&lt;/puf:TaxSubtotalExtension&gt;</span>
+                <span class="tag">&lt;/puf:PageroExtension&gt;</span>
+            <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
+        <span class="tag">&lt;/ext:UBLExtension&gt;</span>
+    <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+    <span class="tag">&lt;cbc:TaxableAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>5000.00<span class="tag">&lt;/cbc:TaxableAmount&gt;</span>
+    <span class="tag">&lt;cbc:TaxAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>0.00<span class="tag">&lt;/cbc:TaxAmount&gt;</span>
+    <span class="tag">&lt;cac:TaxCategory&gt;</span>
+        <span class="tag">&lt;cbc:ID&gt;</span>E<span class="tag">&lt;/cbc:ID&gt;</span>
+        <span class="tag">&lt;cbc:Percent&gt;</span>0<span class="tag">&lt;/cbc:Percent&gt;</span>
+        <span class="tag">&lt;cac:TaxScheme&gt;</span>
+            <span class="tag">&lt;cbc:ID&gt;</span>VAT<span class="tag">&lt;/cbc:ID&gt;</span>
+        <span class="tag">&lt;/cac:TaxScheme&gt;</span>
+    <span class="tag">&lt;/cac:TaxCategory&gt;</span>
+<span class="tag">&lt;/cac:TaxSubtotal&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Code <code>02</code> - Export operations</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_tax_exemption_codes"><a class="anchor" href="#_tax_exemption_codes"></a><a class="link" href="#_tax_exemption_codes">Tax Exemption Codes</a></h5>
+<div class="paragraph">
+<p>When the tax category is <strong>E</strong> (Exempt) or <strong>O</strong> (Outside scope), a tax exemption reason code must be provided.</p>
+</div>
+<div class="paragraph">
+<p>See <a href="https://pagero.github.io/puf-code-lists/#_tax_exemption_codes_in_spain_verifactu" target="_blank" rel="noopener">PUF-013-TAXEXEMPTIONCODE (Spain section)</a> for the complete list of exemption codes.</p>
+</div>
+<div class="paragraph">
+<p><strong>Example - Exempt Operation (Article 21)</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;cac:TaxSubtotal&gt;</span>
+    <span class="tag">&lt;ext:UBLExtensions&gt;</span>
+        <span class="tag">&lt;ext:UBLExtension&gt;</span>
+            <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
+            <span class="tag">&lt;ext:ExtensionContent&gt;</span>
+                <span class="tag">&lt;puf:PageroExtension&gt;</span>
+                    <span class="tag">&lt;puf:TaxSubtotalExtension&gt;</span>
+                        <span class="tag">&lt;puf:SpecialRegimeKey&gt;</span>01<span class="tag">&lt;/puf:SpecialRegimeKey&gt;</span><i class="conum" data-value="3"></i><b>(3)</b>
+                    <span class="tag">&lt;/puf:TaxSubtotalExtension&gt;</span>
+                <span class="tag">&lt;/puf:PageroExtension&gt;</span>
+            <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
+        <span class="tag">&lt;/ext:UBLExtension&gt;</span>
+    <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+    <span class="tag">&lt;cbc:TaxableAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>2000.00<span class="tag">&lt;/cbc:TaxableAmount&gt;</span>
+    <span class="tag">&lt;cbc:TaxAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>0.00<span class="tag">&lt;/cbc:TaxAmount&gt;</span>
+    <span class="tag">&lt;cac:TaxCategory&gt;</span>
+        <span class="tag">&lt;cbc:ID&gt;</span>E<span class="tag">&lt;/cbc:ID&gt;</span>
+        <span class="tag">&lt;cbc:Percent&gt;</span>0<span class="tag">&lt;/cbc:Percent&gt;</span>
+        <span class="tag">&lt;cbc:TaxExemptionReasonCode&gt;</span>E2<span class="tag">&lt;/cbc:TaxExemptionReasonCode&gt;</span><i class="conum" data-value="1"></i><b>(1)</b>
+        <span class="tag">&lt;cbc:TaxExemptionReason&gt;</span>Exenta por el artículo 21<span class="tag">&lt;/cbc:TaxExemptionReason&gt;</span><i class="conum" data-value="2"></i><b>(2)</b>
+        <span class="tag">&lt;cac:TaxScheme&gt;</span>
+            <span class="tag">&lt;cbc:ID&gt;</span>VAT<span class="tag">&lt;/cbc:ID&gt;</span>
+        <span class="tag">&lt;/cac:TaxScheme&gt;</span>
+    <span class="tag">&lt;/cac:TaxCategory&gt;</span>
+<span class="tag">&lt;/cac:TaxSubtotal&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Exemption code <code>E2</code> - Exempt pursuant to Article 21</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Human-readable exemption reason</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Special regime key is still required for exempt operations</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><strong>Example - Not Subject (Location Rules)</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;cac:TaxSubtotal&gt;</span>
+    <span class="tag">&lt;ext:UBLExtensions&gt;</span>
+        <span class="tag">&lt;ext:UBLExtension&gt;</span>
+            <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
+            <span class="tag">&lt;ext:ExtensionContent&gt;</span>
+                <span class="tag">&lt;puf:PageroExtension&gt;</span>
+                    <span class="tag">&lt;puf:TaxSubtotalExtension&gt;</span>
+                        <span class="tag">&lt;puf:SpecialRegimeKey&gt;</span>01<span class="tag">&lt;/puf:SpecialRegimeKey&gt;</span><i class="conum" data-value="3"></i><b>(3)</b>
+                    <span class="tag">&lt;/puf:TaxSubtotalExtension&gt;</span>
+                <span class="tag">&lt;/puf:PageroExtension&gt;</span>
+            <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
+        <span class="tag">&lt;/ext:UBLExtension&gt;</span>
+    <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+    <span class="tag">&lt;cbc:TaxableAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>3000.00<span class="tag">&lt;/cbc:TaxableAmount&gt;</span>
+    <span class="tag">&lt;cbc:TaxAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>0.00<span class="tag">&lt;/cbc:TaxAmount&gt;</span>
+    <span class="tag">&lt;cac:TaxCategory&gt;</span>
+        <span class="tag">&lt;cbc:ID&gt;</span>O<span class="tag">&lt;/cbc:ID&gt;</span>
+        <span class="tag">&lt;cbc:Percent&gt;</span>0<span class="tag">&lt;/cbc:Percent&gt;</span>
+        <span class="tag">&lt;cbc:TaxExemptionReasonCode&gt;</span>N2<span class="tag">&lt;/cbc:TaxExemptionReasonCode&gt;</span><i class="conum" data-value="1"></i><b>(1)</b>
+        <span class="tag">&lt;cbc:TaxExemptionReason&gt;</span>No sujeta por reglas de localización<span class="tag">&lt;/cbc:TaxExemptionReason&gt;</span><i class="conum" data-value="2"></i><b>(2)</b>
+        <span class="tag">&lt;cac:TaxScheme&gt;</span>
+            <span class="tag">&lt;cbc:ID&gt;</span>VAT<span class="tag">&lt;/cbc:ID&gt;</span>
+        <span class="tag">&lt;/cac:TaxScheme&gt;</span>
+    <span class="tag">&lt;/cac:TaxCategory&gt;</span>
+<span class="tag">&lt;/cac:TaxSubtotal&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>No-subject code <code>N2</code> - Not subject due to location rules</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Human-readable reason</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Special regime key is still required for not-subject operations</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_equivalence_surcharge_recargo_de_equivalencia"><a class="anchor" href="#_equivalence_surcharge_recargo_de_equivalencia"></a><a class="link" href="#_equivalence_surcharge_recargo_de_equivalencia">Equivalence Surcharge (Recargo de Equivalencia)</a></h5>
+<div class="paragraph">
+<p>The equivalence surcharge is a special tax regime applicable to certain retail traders in Spain. When applicable, both the rate and amount must be provided using PUF extensions.</p>
+</div>
+<div class="paragraph">
+<p><strong>Example - Equivalence Surcharge</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;cac:TaxSubtotal&gt;</span>
+    <span class="tag">&lt;ext:UBLExtensions&gt;</span>
+        <span class="tag">&lt;ext:UBLExtension&gt;</span>
+            <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
+            <span class="tag">&lt;ext:ExtensionContent&gt;</span>
+                <span class="tag">&lt;puf:PageroExtension&gt;</span>
+                    <span class="tag">&lt;puf:TaxSubtotalExtension&gt;</span>
+                        <span class="tag">&lt;puf:SpecialRegimeKey&gt;</span>18<span class="tag">&lt;/puf:SpecialRegimeKey&gt;</span><i class="conum" data-value="2"></i><b>(2)</b>
+                        <span class="tag">&lt;puf:EquivalenceSurcharge&gt;</span>
+                            <span class="tag">&lt;cbc:Percent&gt;</span>5.2<span class="tag">&lt;/cbc:Percent&gt;</span><i class="conum" data-value="3"></i><b>(3)</b>
+                            <span class="tag">&lt;puf:Amount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>52.00<span class="tag">&lt;/puf:Amount&gt;</span><i class="conum" data-value="4"></i><b>(4)</b>
+                        <span class="tag">&lt;/puf:EquivalenceSurcharge&gt;</span>
+                    <span class="tag">&lt;/puf:TaxSubtotalExtension&gt;</span>
+                <span class="tag">&lt;/puf:PageroExtension&gt;</span>
+            <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
+        <span class="tag">&lt;/ext:UBLExtension&gt;</span>
+    <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+    <span class="tag">&lt;cbc:TaxableAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>1000.00<span class="tag">&lt;/cbc:TaxableAmount&gt;</span>
+    <span class="tag">&lt;cbc:TaxAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>210.00<span class="tag">&lt;/cbc:TaxAmount&gt;</span><i class="conum" data-value="1"></i><b>(1)</b>
+    <span class="tag">&lt;cac:TaxCategory&gt;</span>
+        <span class="tag">&lt;cbc:ID&gt;</span>S<span class="tag">&lt;/cbc:ID&gt;</span>
+        <span class="tag">&lt;cbc:Percent&gt;</span>21.0<span class="tag">&lt;/cbc:Percent&gt;</span>
+        <span class="tag">&lt;cac:TaxScheme&gt;</span>
+            <span class="tag">&lt;cbc:ID&gt;</span>VAT<span class="tag">&lt;/cbc:ID&gt;</span>
+        <span class="tag">&lt;/cac:TaxScheme&gt;</span>
+    <span class="tag">&lt;/cac:TaxCategory&gt;</span>
+<span class="tag">&lt;/cac:TaxSubtotal&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Tax amount (IVA) = 1000.00 × 21% = 210.00</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Special regime key <code>18</code> indicates equivalence surcharge</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Equivalence surcharge rate (5.2%)</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>Equivalence surcharge amount = 1000.00 × 5.2% = 52.00</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_tax_base_at_cost_2"><a class="anchor" href="#_tax_base_at_cost_2"></a><a class="link" href="#_tax_base_at_cost_2">Tax Base at Cost</a></h5>
+<div class="paragraph">
+<p>For special group regimes, a tax base at cost may be required:</p>
+</div>
+<div class="paragraph">
+<p><strong>Example - Tax Base at Cost</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;cac:TaxSubtotal&gt;</span>
+    <span class="tag">&lt;ext:UBLExtensions&gt;</span>
+        <span class="tag">&lt;ext:UBLExtension&gt;</span>
+            <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
+            <span class="tag">&lt;ext:ExtensionContent&gt;</span>
+                <span class="tag">&lt;puf:PageroExtension&gt;</span>
+                    <span class="tag">&lt;puf:TaxSubtotalExtension&gt;</span>
+                        <span class="tag">&lt;puf:SpecialRegimeKey&gt;</span>06<span class="tag">&lt;/puf:SpecialRegimeKey&gt;</span><i class="conum" data-value="1"></i><b>(1)</b>
+                        <span class="tag">&lt;puf:TaxBaseAtCost</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>950.00<span class="tag">&lt;/puf:TaxBaseAtCost&gt;</span><i class="conum" data-value="2"></i><b>(2)</b>
+                    <span class="tag">&lt;/puf:TaxSubtotalExtension&gt;</span>
+                <span class="tag">&lt;/puf:PageroExtension&gt;</span>
+            <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
+        <span class="tag">&lt;/ext:UBLExtension&gt;</span>
+    <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+    <span class="tag">&lt;cbc:TaxableAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>1000.00<span class="tag">&lt;/cbc:TaxableAmount&gt;</span>
+    <span class="tag">&lt;cbc:TaxAmount</span> <span class="attribute-name">currencyID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">EUR</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>210.00<span class="tag">&lt;/cbc:TaxAmount&gt;</span>
+    <span class="tag">&lt;cac:TaxCategory&gt;</span>
+        <span class="tag">&lt;cbc:ID&gt;</span>S<span class="tag">&lt;/cbc:ID&gt;</span>
+        <span class="tag">&lt;cbc:Percent&gt;</span>21.0<span class="tag">&lt;/cbc:Percent&gt;</span>
+        <span class="tag">&lt;cac:TaxScheme&gt;</span>
+            <span class="tag">&lt;cbc:ID&gt;</span>VAT<span class="tag">&lt;/cbc:ID&gt;</span>
+        <span class="tag">&lt;/cac:TaxScheme&gt;</span>
+    <span class="tag">&lt;/cac:TaxCategory&gt;</span>
+<span class="tag">&lt;/cac:TaxSubtotal&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Special regime key <code>06</code> - VAT group advanced level</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Tax base at cost for special group regime calculation</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_related_resources"><a class="anchor" href="#_related_resources"></a><a class="link" href="#_related_resources">5.16.7. Related Resources</a></h4>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://pagero.github.io/puf-code-lists/#_puf_003_invoicetypecode" target="_blank" rel="noopener">PUF-003-INVOICETYPECODE</a> - Invoice type codes</p>
+</li>
+<li>
+<p><a href="https://pagero.github.io/puf-code-lists/#_identification_scheme_spain" target="_blank" rel="noopener">PUF-008-IDENTIFICATIONSCHEME (Spain)</a> - Spanish identification schemes</p>
+</li>
+<li>
+<p><a href="https://pagero.github.io/puf-code-lists/#_puf_012_taxcategorycode" target="_blank" rel="noopener">PUF-012-TAXCATEGORYCODE</a> - Tax category codes</p>
+</li>
+<li>
+<p><a href="https://pagero.github.io/puf-code-lists/#_tax_exemption_codes_in_spain_verifactu" target="_blank" rel="noopener">PUF-013-TAXEXEMPTIONCODE (Spain)</a> - Tax exemption and no-subject codes</p>
+</li>
+<li>
+<p><a href="https://pagero.github.io/puf-code-lists/#_puf_022_specialregimekey" target="_blank" rel="noopener">PUF-022-SPECIALREGIMEKEY</a> - Special regime keys for Spanish tax operations</p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_türkiye"><a class="anchor" href="#_türkiye"></a><a class="link" href="#_türkiye">5.17. Türkiye</a></h3>
 <div class="paragraph">
 <p>This section contains information about special requirements concerning invoicing in Türkiye.</p>
 </div>
 <div class="sect3">
-<h4 id="_invoice_profile_id"><a class="anchor" href="#_invoice_profile_id"></a><a class="link" href="#_invoice_profile_id">5.16.1. Invoice profile id</a></h4>
+<h4 id="_invoice_profile_id"><a class="anchor" href="#_invoice_profile_id"></a><a class="link" href="#_invoice_profile_id">5.17.1. Invoice profile id</a></h4>
 <div class="paragraph">
 <p>For the UBL-TR format in Türkiye, it is mandatory to specify the invoice profile that&#8217;s used.</p>
 </div>
@@ -13937,7 +15138,7 @@ can be provided. Note that in this scenario the QR string must be sent as plain 
 </div>
 </div>
 <div class="sect3">
-<h4 id="_invoice_type_code"><a class="anchor" href="#_invoice_type_code"></a><a class="link" href="#_invoice_type_code">5.16.2. Invoice type code</a></h4>
+<h4 id="_invoice_type_code"><a class="anchor" href="#_invoice_type_code"></a><a class="link" href="#_invoice_type_code">5.17.2. Invoice type code</a></h4>
 <div class="paragraph">
 <p>In addition to the invoice profile, it is also required to indicate the invoice type. This should be indicated in the attribute <code>name`</code> belonging to the element <code>cbc:InvoiceTypeCode</code>.</p>
 </div>
@@ -14005,7 +15206,7 @@ can be provided. Note that in this scenario the QR string must be sent as plain 
 </div>
 </div>
 <div class="sect3">
-<h4 id="_invoice_delivery_method"><a class="anchor" href="#_invoice_delivery_method"></a><a class="link" href="#_invoice_delivery_method">5.16.3. Invoice delivery method</a></h4>
+<h4 id="_invoice_delivery_method"><a class="anchor" href="#_invoice_delivery_method"></a><a class="link" href="#_invoice_delivery_method">5.17.3. Invoice delivery method</a></h4>
 <div class="paragraph">
 <p>If the invoice profile id is set as "EARSIVFATURA" it is mandatory to include how the invoice is being distributed.
 There are only two allowed values. If Pagero is to do the invoice distribution, you should always enter "ELEKTRONIK".
@@ -14060,7 +15261,7 @@ If an e-mail address for the buyer exists (see <code>cac:AccountingContact/cbc:E
 </div>
 </div>
 <div class="sect3">
-<h4 id="_first_name_and_surname"><a class="anchor" href="#_first_name_and_surname"></a><a class="link" href="#_first_name_and_surname">5.16.4. First name and surname</a></h4>
+<h4 id="_first_name_and_surname"><a class="anchor" href="#_first_name_and_surname"></a><a class="link" href="#_first_name_and_surname">5.17.4. First name and surname</a></h4>
 <div class="paragraph">
 <p>If the buyer is a private person (uses TCKN), the first name and surname of the buyer should be included in specific elements.</p>
 </div>
@@ -14113,7 +15314,7 @@ If an e-mail address for the buyer exists (see <code>cac:AccountingContact/cbc:E
 </div>
 </div>
 <div class="sect3">
-<h4 id="_registered_tax_office"><a class="anchor" href="#_registered_tax_office"></a><a class="link" href="#_registered_tax_office">5.16.5. Registered tax office</a></h4>
+<h4 id="_registered_tax_office"><a class="anchor" href="#_registered_tax_office"></a><a class="link" href="#_registered_tax_office">5.17.5. Registered tax office</a></h4>
 <div class="paragraph">
 <p>The specific tax office where the buyer or seller is registered for tax purposes.</p>
 </div>
@@ -14155,13 +15356,13 @@ If an e-mail address for the buyer exists (see <code>cac:AccountingContact/cbc:E
 </div>
 </div>
 <div class="sect3">
-<h4 id="_tax_category_codes_5"><a class="anchor" href="#_tax_category_codes_5"></a><a class="link" href="#_tax_category_codes_5">5.16.6. Tax category codes</a></h4>
+<h4 id="_tax_category_codes_5"><a class="anchor" href="#_tax_category_codes_5"></a><a class="link" href="#_tax_category_codes_5">5.17.6. Tax category codes</a></h4>
 <div class="paragraph">
 <p>Tax category codes for Türkiye are numerous and can be found here: <a href="https://pagero.github.io/puf-code-lists/#_tax_category_codes_türkiye" target="_blank" rel="noopener">Tax category codes Türkiye</a>.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_tax_scheme"><a class="anchor" href="#_tax_scheme"></a><a class="link" href="#_tax_scheme">5.16.7. Tax scheme</a></h4>
+<h4 id="_tax_scheme"><a class="anchor" href="#_tax_scheme"></a><a class="link" href="#_tax_scheme">5.17.7. Tax scheme</a></h4>
 <div class="paragraph">
 <p>In Türkiye there are various types of taxes in addition to the regular VAT (known as "KDV" in Türkiye).
 Another relatively common tax is what&#8217;s known as "ÖTV", or Special Consumption Tax. This applies to sales of products such as alcohol, mobile phones, cars, and tobacco. In the event an invoice is applicable for this Special Consumption Tax, it needs to be indicated in the <code>cac:TaxScheme/cbc:ID</code> element on both line and header level.</p>
@@ -14204,7 +15405,7 @@ Another relatively common tax is what&#8217;s known as "ÖTV", or Special Consum
 </div>
 </div>
 <div class="sect3">
-<h4 id="_internet_sales"><a class="anchor" href="#_internet_sales"></a><a class="link" href="#_internet_sales">5.16.8. Internet Sales</a></h4>
+<h4 id="_internet_sales"><a class="anchor" href="#_internet_sales"></a><a class="link" href="#_internet_sales">5.17.8. Internet Sales</a></h4>
 <div class="paragraph">
 <p>If the invoice is the result of an online sale, extra information needs to be included in the invoice, if applicable.</p>
 </div>
@@ -14334,12 +15535,12 @@ Otherwise it is OK to omit the attribute.</td>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_united_states"><a class="anchor" href="#_united_states"></a><a class="link" href="#_united_states">5.17. United States</a></h3>
+<h3 id="_united_states"><a class="anchor" href="#_united_states"></a><a class="link" href="#_united_states">5.18. United States</a></h3>
 <div class="paragraph">
 <p>This section contains information about requirements and other information concerning invoicing in United States of America.</p>
 </div>
 <div class="sect3">
-<h4 id="_tax_scheme_2"><a class="anchor" href="#_tax_scheme_2"></a><a class="link" href="#_tax_scheme_2">5.17.1. Tax scheme</a></h4>
+<h4 id="_tax_scheme_2"><a class="anchor" href="#_tax_scheme_2"></a><a class="link" href="#_tax_scheme_2">5.18.1. Tax scheme</a></h4>
 <div class="paragraph">
 <p>Since taxes vary in different states and there are a number of local taxes as well, Pagero recommends to specify State and Local Tax in the following way:<br>
 - For State Tax use <code>cac:TaxScheme/cbc:ID</code> with value <code>STT</code>.<br>
@@ -14400,7 +15601,7 @@ Otherwise it is OK to omit the attribute.</td>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_party_identification_7"><a class="anchor" href="#_party_identification_7"></a><a class="link" href="#_party_identification_7">5.17.2. Party identification</a></h4>
+<h4 id="_party_identification_8"><a class="anchor" href="#_party_identification_8"></a><a class="link" href="#_party_identification_8">5.18.2. Party identification</a></h4>
 <div class="paragraph">
 <p>There is no party identifiers available in the ISO 6523 ICD list for USA at the moment.
 To specify Tax Identification Number please use 'cac:PartyTaxScheme/cbc:CompanyID'</p>
@@ -14433,12 +15634,12 @@ To specify Tax Identification Number please use 'cac:PartyTaxScheme/cbc:CompanyI
 </div>
 </div>
 <div class="sect2">
-<h3 id="_vietnam"><a class="anchor" href="#_vietnam"></a><a class="link" href="#_vietnam">5.18. Vietnam</a></h3>
+<h3 id="_vietnam"><a class="anchor" href="#_vietnam"></a><a class="link" href="#_vietnam">5.19. Vietnam</a></h3>
 <div class="paragraph">
 <p>This section contains information about requirements and other information concerning invoicing in Vietnam.</p>
 </div>
 <div class="sect3">
-<h4 id="_invoice_serial_and_sequence_number"><a class="anchor" href="#_invoice_serial_and_sequence_number"></a><a class="link" href="#_invoice_serial_and_sequence_number">5.18.1. Invoice, Serial and Sequence Number</a></h4>
+<h4 id="_invoice_serial_and_sequence_number"><a class="anchor" href="#_invoice_serial_and_sequence_number"></a><a class="link" href="#_invoice_serial_and_sequence_number">5.19.1. Invoice, Serial and Sequence Number</a></h4>
 <div class="paragraph">
 <p>In Vietnam, each e-invoice is assigned a unique serial number, which serves as its identifier. Additionally, a sequence number is used, which increments with each new invoice issued.<br>
 An internally generated invoice number from an ERP system can be included in the 'cac:BillingReference' segment.<br>
@@ -14506,7 +15707,7 @@ For enhanced search functionality in Pagero Online, it is recommended to use a c
 </div>
 </div>
 <div class="sect3">
-<h4 id="_invoice_type_code_2"><a class="anchor" href="#_invoice_type_code_2"></a><a class="link" href="#_invoice_type_code_2">5.18.2. Invoice Type Code</a></h4>
+<h4 id="_invoice_type_code_2"><a class="anchor" href="#_invoice_type_code_2"></a><a class="link" href="#_invoice_type_code_2">5.19.2. Invoice Type Code</a></h4>
 <div class="paragraph">
 <p>In addition to Invoice Type Code the 'name' attribute is used to provide the Vietnameese invoice type.</p>
 </div>
@@ -14552,7 +15753,7 @@ For enhanced search functionality in Pagero Online, it is recommended to use a c
 <p>Below is a list of countries where PUF can be used as the source for tax data reporting with distribution solely to tax authorities.</p>
 </div>
 <table class="tableblock frame-all grid-all fit-content stretch">
-<caption class="title">Table 70. Table of PUF supported countries for Tax data reporting</caption>
+<caption class="title">Table 71. Table of PUF supported countries for Tax data reporting</caption>
 <colgroup>
 <col>
 <col>
@@ -14701,7 +15902,7 @@ If no entry type is sent system will default to type Invoice.
 <div class="sect2">
 <h3 id="_code_lists_for_coded_elements"><a class="anchor" href="#_code_lists_for_coded_elements"></a><a class="link" href="#_code_lists_for_coded_elements">7.1. Code lists for coded elements</a></h3>
 <table class="tableblock frame-all grid-all fit-content stretch">
-<caption class="title">Table 71. Table of the code lists used</caption>
+<caption class="title">Table 72. Table of the code lists used</caption>
 <colgroup>
 <col>
 <col>
@@ -14879,7 +16080,7 @@ cbc:ItemClassificationCode/@listID</code></p></td>
 <p>The validation artefacts are also available on <a href="https://github.com/pagero/puf-billing/tree/master/validation-artefacts" target="_blank" rel="noopener">GitHub</a>.</p>
 </div>
 <table class="tableblock frame-all grid-all fit-content stretch">
-<caption class="title">Table 72. Schematron rules in PUF</caption>
+<caption class="title">Table 73. Schematron rules in PUF</caption>
 <colgroup>
 <col>
 <col>
@@ -15059,7 +16260,7 @@ The "Require ext:UBLExtensions"-column indicates whether or not the use of UBL e
 </table>
 </div>
 <table class="tableblock frame-all grid-all fit-content stretch">
-<caption class="title">Table 73. Table of supported countries</caption>
+<caption class="title">Table 74. Table of supported countries</caption>
 <colgroup>
 <col>
 <col>
@@ -15114,7 +16315,7 @@ The "Require ext:UBLExtensions"-column indicates whether or not the use of UBL e
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Croatia</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Yes</strong></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>No</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Yes</strong></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
@@ -15262,6 +16463,12 @@ The "Require ext:UBLExtensions"-column indicates whether or not the use of UBL e
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Philippines</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Yes</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Yes</strong></p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Portugal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Yes</strong></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Yes</strong></p></td>
@@ -15317,6 +16524,13 @@ The "Require ext:UBLExtensions"-column indicates whether or not the use of UBL e
 Only support for invoice and credit.</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Spain (VeriFactu)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Yes</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Yes</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Support for VeriFactu.<br>
+Only support for invoice and credit/correction.</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Sweden</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Yes</strong></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>No</strong></p></td>
@@ -15350,7 +16564,7 @@ Only support for invoice and credit.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Vietnam</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Yes</strong></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Yes</strong></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Only support for 'new' Invoice. See <a href="#_limitations">limitations</a> for more information.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Only support for 'new' Invoice.</p></td>
 </tr>
 </tbody>
 </table>

--- a/specification/country-specifics.adoc
+++ b/specification/country-specifics.adoc
@@ -20,7 +20,6 @@ include::country-specifics/france.adoc[]
 
 include::country-specifics/greece.adoc[]
 
-
 === Hungary
 
 include::country-specifics/hungary.adoc[]
@@ -60,6 +59,10 @@ include::country-specifics/singapore.adoc[]
 === Spain
 
 include::country-specifics/spain.adoc[]
+
+=== Spain VeriFactu
+
+include::country-specifics/spain-verifactu.adoc[]
 
 === Türkiye
 

--- a/specification/country-specifics/spain-verifactu.adoc
+++ b/specification/country-specifics/spain-verifactu.adoc
@@ -1,0 +1,549 @@
+This section contains information about requirements and other information concerning VeriFactu e-invoicing in Spain.
+
+==== Invoice Number and Invoice Series
+
+VeriFactu requires both an invoice number and an invoice series to uniquely identify invoices.
+
+The invoice number is provided in the standard `cbc:ID` element.
+
+The invoice series must be provided using a PUF extension:
+
+*Example*
+[source,xml]
+----
+<Invoice>
+    <ext:UBLExtensions>
+        <ext:UBLExtension>
+            <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:InvoiceSeries</ext:ExtensionURI>
+            <ext:ExtensionContent>
+                <puf:PageroExtension>
+                    <puf:InvoiceSeries>
+                        <cbc:ID>2025-A</cbc:ID>
+                    </puf:InvoiceSeries>
+                </puf:PageroExtension>
+            </ext:ExtensionContent>
+        </ext:UBLExtension>
+    </ext:UBLExtensions>
+    <cbc:ID>001</cbc:ID>
+    <!-- Code omitted for clarity -->
+</Invoice>
+----
+
+==== Document Type Specification
+
+VeriFactu distinguishes between different document types including standard invoices, simplified invoices, and corrective invoices. The document type is specified using the `cbc:InvoiceTypeCode` element with an additional `@name` attribute containing the Spanish invoice type identifier (F1-F3 for invoices, R1-R5 for rectifications).
+
+See https://pagero.github.io/puf-code-lists/#_invoice_type_codes_for_spain_verifactu[PUF-003-INVOICETYPECODE (Spain VeriFactu)^] for the complete list of invoice type codes.
+
+===== Standard Invoices
+
+*Standard Invoice (F1)*
+[source,xml]
+----
+<Invoice>
+    <cbc:InvoiceTypeCode name="F1">380</cbc:InvoiceTypeCode><!--1-->
+    <!-- Code omitted for clarity -->
+</Invoice>
+----
+<1> F1 - Factura (art. 6, 7.2 y 7.3 del RD 1619/2012)
+
+*Simplified Invoice (F2)*
+[source,xml]
+----
+<Invoice>
+    <cbc:InvoiceTypeCode name="F2">380</cbc:InvoiceTypeCode><!--1-->
+    <!-- Code omitted for clarity -->
+</Invoice>
+----
+<1> F2 - Factura Simplificada y Facturas sin identificación del destinatario art. 6.1.d) RD 1619/2012
+
+===== Corrective Invoices
+
+Corrective invoices can be issued using either Invoice (type code 384) or CreditNote (type code 381) depending on the business scenario.
+
+*Corrective Invoice - Legal Error (R1)*
+[source,xml]
+----
+<Invoice>
+    <cbc:InvoiceTypeCode name="R1">384</cbc:InvoiceTypeCode><!--1-->
+    <!-- Code omitted for clarity -->
+</Invoice>
+----
+<1> R1 - Factura Rectificativa (Error fundado en derecho y Art. 80 Uno Dos y Seis LIVA)
+
+*Credit Note - Legal Error (R1)*
+[source,xml]
+----
+<CreditNote>
+    <cbc:CreditNoteTypeCode name="R1">381</cbc:CreditNoteTypeCode><!--1-->
+    <!-- Code omitted for clarity -->
+</CreditNote>
+----
+<1> R1 - Factura Rectificativa (Error fundado en derecho y Art. 80 Uno Dos y Seis LIVA)
+
+==== Simplified Invoice Indicator
+
+VeriFactu separates the legal invoice type (F1/F2/F3, R1-R5) from the Article 7.2/7.3 simplified qualifier. Use `cbc:InvoiceTypeCode/@name` for the invoice type (e.g. F2) and only include the `puf:Simplified` extension when the invoice meets the specific Article 7.2/7.3 conditions. For other types it must be omitted. If omitted on an F2 invoice, the default is false.
+
+*Example*
+[source,xml]
+----
+<Invoice>
+    <!-- Code omitted for clarity -->
+    <ext:UBLExtensions>
+        <ext:UBLExtension>
+            <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:Simplified</ext:ExtensionURI>
+            <ext:ExtensionContent>
+                <puf:PageroExtension>
+                    <puf:Simplified>true</puf:Simplified><!--1-->
+                </puf:PageroExtension>
+            </ext:ExtensionContent>
+        </ext:UBLExtension>
+    </ext:UBLExtensions>
+    <!-- Code omitted for clarity -->
+</Invoice>
+----
+<1> Supported values: `true` (yes) or `false` (no - default if not provided)
+
+==== Correction Information
+
+When issuing corrective invoices (credit notes or corrections), VeriFactu requires specific information about the original invoice being corrected.
+
+===== Correction Type
+
+Spain VeriFactu requires specifying the correction method:
+
+* `I` - Correction by differences (corrección por diferencias)
+* `S` - Substitutive method (método sustitutivo)
+
+===== Billing Reference Structure
+
+The correction information is provided in the `cac:BillingReference` section with PUF extensions:
+
+*Example - Correction by Differences*
+[source,xml]
+----
+<Invoice>
+    <cbc:InvoiceTypeCode>384</cbc:InvoiceTypeCode>
+    <!-- Code omitted for clarity -->
+    <cac:BillingReference>
+        <cac:InvoiceDocumentReference>
+            <cbc:ID>001</cbc:ID><!--1-->
+            <cbc:IssueDate>2025-01-15</cbc:IssueDate><!--2-->
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:BillingReferenceExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:BillingReferenceExtension>
+                                <puf:Code>I</puf:Code><!--3-->
+                                <puf:InvoiceSeries>
+                                    <cbc:ID>2025-A</cbc:ID><!--4-->
+                                </puf:InvoiceSeries>
+                            </puf:BillingReferenceExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+        </cac:InvoiceDocumentReference>
+    </cac:BillingReference>
+    <!-- Code omitted for clarity -->
+</Invoice>
+----
+<1> Corrected invoice number
+<2> Corrected invoice issue date
+<3> Correction type: `I` (differences) or `S` (substitutive)
+<4> Corrected invoice series
+
+===== Substitutive Method Additional Fields
+
+When using the substitutive method (`S`), additional fields are mandatory:
+
+*Example - Substitutive Method*
+[source,xml]
+----
+<Invoice>
+    <cbc:InvoiceTypeCode>384</cbc:InvoiceTypeCode>
+    <!-- Code omitted for clarity -->
+    <cac:BillingReference>
+        <cac:InvoiceDocumentReference>
+            <cbc:ID>001</cbc:ID>
+            <cbc:IssueDate>2025-01-15</cbc:IssueDate>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:BillingReferenceExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:BillingReferenceExtension>
+                                <puf:Code>S</puf:Code>
+                                <puf:InvoiceSeries>
+                                    <cbc:ID>2025-A</cbc:ID>
+                                </puf:InvoiceSeries>
+                                <cbc:TaxableAmount currencyID="EUR">1000.00</cbc:TaxableAmount><!--1-->
+                                <cbc:TaxAmount currencyID="EUR">210.00</cbc:TaxAmount><!--2-->
+                                <puf:EquivalenceSurchargeAmount currencyID="EUR">5.00</puf:EquivalenceSurchargeAmount><!--3-->
+                            </puf:BillingReferenceExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+        </cac:InvoiceDocumentReference>
+    </cac:BillingReference>
+    <!-- Code omitted for clarity -->
+</Invoice>
+----
+<1> Corrected invoice tax base (mandatory for substitutive method)
+<2> Corrected invoice tax amount (mandatory for substitutive method)
+<3> Corrected invoice equivalence surcharge (conditionally mandatory)
+
+==== Party Identification
+
+===== Seller Information
+
+The seller's Spanish Tax Identification Number (NIF) must be provided in the `cac:PartyTaxScheme` structure:
+
+*Example*
+[source,xml]
+----
+<Invoice>
+    <!-- Code omitted for clarity -->
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>ESB12345678</cbc:CompanyID><!--1-->
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <!-- Code omitted for clarity -->
+</Invoice>
+----
+<1> Spanish NIF with ES prefix
+
+===== Buyer Information
+
+For the buyer, the VAT number is conditionally mandatory. If the buyer is a Spanish entity, the NIF should be provided. If the buyer does not have a VAT number, an alternative identification must be provided.
+
+*Example - Buyer with VAT Number*
+[source,xml]
+----
+<Invoice>
+    <!-- Code omitted for clarity -->
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>ESB87654321</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    <!-- Code omitted for clarity -->
+</Invoice>
+----
+
+*Example - Buyer with Alternative Identification*
+[source,xml]
+----
+<Invoice>
+    <!-- Code omitted for clarity -->
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="ES:PASSPORT">AB123456</cbc:ID><!--1-->
+            </cac:PartyIdentification>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    <!-- Code omitted for clarity -->
+</Invoice>
+----
+<1> Alternative identification using scheme codes from https://pagero.github.io/puf-code-lists/#_identification_scheme_spain[PUF-008-IDENTIFICATIONSCHEME^]
+
+==== Tax Details
+
+Spain VeriFactu requires comprehensive tax information including tax type, tax category, special regime keys, and exemption codes.
+
+===== Tax Types
+
+VeriFactu supports three tax types:
+
+* **VAT** (IVA) - Standard Spanish VAT used throughout Spain
+* **IGIC** - Special tax for the Canary Islands
+* **IPSI** - Special tax for Ceuta and Melilla
+
+The tax type is specified in `cac:TaxScheme/cbc:ID`:
+
+*Example - IVA (VAT)*
+[source,xml]
+----
+<cac:TaxCategory>
+    <cbc:ID>S</cbc:ID>
+    <cbc:Percent>21.0</cbc:Percent>
+    <cac:TaxScheme>
+        <cbc:ID>VAT</cbc:ID><!--1-->
+    </cac:TaxScheme>
+</cac:TaxCategory>
+----
+<1> Use `VAT` for IVA operations
+
+*Example - IGIC (Canary Islands)*
+[source,xml]
+----
+<cac:TaxCategory>
+    <cbc:ID>S</cbc:ID>
+    <cbc:Percent>7.0</cbc:Percent>
+    <cac:TaxScheme>
+        <cbc:ID>IGIC</cbc:ID><!--1-->
+    </cac:TaxScheme>
+</cac:TaxCategory>
+----
+<1> Use `IGIC` for Canary Islands operations
+
+*Example - IPSI (Ceuta/Melilla)*
+[source,xml]
+----
+<cac:TaxCategory>
+    <cbc:ID>S</cbc:ID>
+    <cbc:Percent>10.0</cbc:Percent>
+    <cac:TaxScheme>
+        <cbc:ID>IPSI</cbc:ID><!--1-->
+    </cac:TaxScheme>
+</cac:TaxCategory>
+----
+<1> Use `IPSI` for Ceuta and Melilla operations
+
+===== Tax Categories
+
+VeriFactu uses standard tax category codes from UNCL5305. Common codes include:
+
+* **S** - Standard rate
+* **AE** - Reverse Charge
+* **E** - Exempt from tax
+* **O** - Not subject to tax (outside scope)
+* **Z** - Zero rated
+
+See https://pagero.github.io/puf-code-lists/#_puf_012_taxcategorycode[PUF-012-TAXCATEGORYCODE^] for more details.
+
+===== Special Regime Keys (ClaveRegimen)
+
+**Mandatory for VeriFactu**: Every tax breakdown must include a Special Regime Key (ClaveRegimen) that identifies the tax regime type or special transaction scheme.
+
+The special regime key is provided using a PUF extension within the `cac:TaxSubtotal` structure. The applicable codes depend on the tax type (VAT/IGIC/IPSI).
+
+For a complete list of special regime keys, see https://pagero.github.io/puf-code-lists/#_puf_022_specialregimekey[PUF-022-SPECIALREGIMEKEY^].
+
+*Example - IVA General Regime (Code 01)*
+[source,xml]
+----
+<cac:TaxSubtotal>
+    <ext:UBLExtensions>
+        <ext:UBLExtension>
+            <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension</ext:ExtensionURI>
+            <ext:ExtensionContent>
+                <puf:PageroExtension>
+                    <puf:TaxSubtotalExtension>
+                        <puf:SpecialRegimeKey>01</puf:SpecialRegimeKey><!--1-->
+                    </puf:TaxSubtotalExtension>
+                </puf:PageroExtension>
+            </ext:ExtensionContent>
+        </ext:UBLExtension>
+    </ext:UBLExtensions>
+    <cbc:TaxableAmount currencyID="EUR">1000.00</cbc:TaxableAmount>
+    <cbc:TaxAmount currencyID="EUR">210.00</cbc:TaxAmount>
+    <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.0</cbc:Percent>
+        <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+    </cac:TaxCategory>
+</cac:TaxSubtotal>
+----
+<1> Code `01` - General regime (for IVA operations)
+
+*Example - Export Operations (Code 02)*
+[source,xml]
+----
+<cac:TaxSubtotal>
+    <ext:UBLExtensions>
+        <ext:UBLExtension>
+            <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension</ext:ExtensionURI>
+            <ext:ExtensionContent>
+                <puf:PageroExtension>
+                    <puf:TaxSubtotalExtension>
+                        <puf:SpecialRegimeKey>02</puf:SpecialRegimeKey><!--1-->
+                    </puf:TaxSubtotalExtension>
+                </puf:PageroExtension>
+            </ext:ExtensionContent>
+        </ext:UBLExtension>
+    </ext:UBLExtensions>
+    <cbc:TaxableAmount currencyID="EUR">5000.00</cbc:TaxableAmount>
+    <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+    <cac:TaxCategory>
+        <cbc:ID>E</cbc:ID>
+        <cbc:Percent>0</cbc:Percent>
+        <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+    </cac:TaxCategory>
+</cac:TaxSubtotal>
+----
+<1> Code `02` - Export operations
+
+===== Tax Exemption Codes
+
+When the tax category is **E** (Exempt) or **O** (Outside scope), a tax exemption reason code must be provided.
+
+See https://pagero.github.io/puf-code-lists/#_tax_exemption_codes_in_spain_verifactu[PUF-013-TAXEXEMPTIONCODE (Spain section)^] for the complete list of exemption codes.
+
+*Example - Exempt Operation (Article 21)*
+[source,xml]
+----
+<cac:TaxSubtotal>
+    <ext:UBLExtensions>
+        <ext:UBLExtension>
+            <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension</ext:ExtensionURI>
+            <ext:ExtensionContent>
+                <puf:PageroExtension>
+                    <puf:TaxSubtotalExtension>
+                        <puf:SpecialRegimeKey>01</puf:SpecialRegimeKey><!--3-->
+                    </puf:TaxSubtotalExtension>
+                </puf:PageroExtension>
+            </ext:ExtensionContent>
+        </ext:UBLExtension>
+    </ext:UBLExtensions>
+    <cbc:TaxableAmount currencyID="EUR">2000.00</cbc:TaxableAmount>
+    <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+    <cac:TaxCategory>
+        <cbc:ID>E</cbc:ID>
+        <cbc:Percent>0</cbc:Percent>
+        <cbc:TaxExemptionReasonCode>E2</cbc:TaxExemptionReasonCode><!--1-->
+        <cbc:TaxExemptionReason>Exenta por el artículo 21</cbc:TaxExemptionReason><!--2-->
+        <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+    </cac:TaxCategory>
+</cac:TaxSubtotal>
+----
+<1> Exemption code `E2` - Exempt pursuant to Article 21
+<2> Human-readable exemption reason
+<3> Special regime key is still required for exempt operations
+
+*Example - Not Subject (Location Rules)*
+[source,xml]
+----
+<cac:TaxSubtotal>
+    <ext:UBLExtensions>
+        <ext:UBLExtension>
+            <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension</ext:ExtensionURI>
+            <ext:ExtensionContent>
+                <puf:PageroExtension>
+                    <puf:TaxSubtotalExtension>
+                        <puf:SpecialRegimeKey>01</puf:SpecialRegimeKey><!--3-->
+                    </puf:TaxSubtotalExtension>
+                </puf:PageroExtension>
+            </ext:ExtensionContent>
+        </ext:UBLExtension>
+    </ext:UBLExtensions>
+    <cbc:TaxableAmount currencyID="EUR">3000.00</cbc:TaxableAmount>
+    <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+    <cac:TaxCategory>
+        <cbc:ID>O</cbc:ID>
+        <cbc:Percent>0</cbc:Percent>
+        <cbc:TaxExemptionReasonCode>N2</cbc:TaxExemptionReasonCode><!--1-->
+        <cbc:TaxExemptionReason>No sujeta por reglas de localización</cbc:TaxExemptionReason><!--2-->
+        <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+    </cac:TaxCategory>
+</cac:TaxSubtotal>
+----
+<1> No-subject code `N2` - Not subject due to location rules
+<2> Human-readable reason
+<3> Special regime key is still required for not-subject operations
+
+===== Equivalence Surcharge (Recargo de Equivalencia)
+
+The equivalence surcharge is a special tax regime applicable to certain retail traders in Spain. When applicable, both the rate and amount must be provided using PUF extensions.
+
+*Example - Equivalence Surcharge*
+[source,xml]
+----
+<cac:TaxSubtotal>
+    <ext:UBLExtensions>
+        <ext:UBLExtension>
+            <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension</ext:ExtensionURI>
+            <ext:ExtensionContent>
+                <puf:PageroExtension>
+                    <puf:TaxSubtotalExtension>
+                        <puf:SpecialRegimeKey>18</puf:SpecialRegimeKey><!--2-->
+                        <puf:EquivalenceSurcharge>
+                            <cbc:Percent>5.2</cbc:Percent><!--3-->
+                            <puf:Amount currencyID="EUR">52.00</puf:Amount><!--4-->
+                        </puf:EquivalenceSurcharge>
+                    </puf:TaxSubtotalExtension>
+                </puf:PageroExtension>
+            </ext:ExtensionContent>
+        </ext:UBLExtension>
+    </ext:UBLExtensions>
+    <cbc:TaxableAmount currencyID="EUR">1000.00</cbc:TaxableAmount>
+    <cbc:TaxAmount currencyID="EUR">210.00</cbc:TaxAmount><!--1-->
+    <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.0</cbc:Percent>
+        <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+    </cac:TaxCategory>
+</cac:TaxSubtotal>
+----
+<1> Tax amount (IVA) = 1000.00 × 21% = 210.00
+<2> Special regime key `18` indicates equivalence surcharge
+<3> Equivalence surcharge rate (5.2%)
+<4> Equivalence surcharge amount = 1000.00 × 5.2% = 52.00
+
+===== Tax Base at Cost
+
+For special group regimes, a tax base at cost may be required:
+
+*Example - Tax Base at Cost*
+[source,xml]
+----
+<cac:TaxSubtotal>
+    <ext:UBLExtensions>
+        <ext:UBLExtension>
+            <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension</ext:ExtensionURI>
+            <ext:ExtensionContent>
+                <puf:PageroExtension>
+                    <puf:TaxSubtotalExtension>
+                        <puf:SpecialRegimeKey>06</puf:SpecialRegimeKey><!--1-->
+                        <puf:TaxBaseAtCost currencyID="EUR">950.00</puf:TaxBaseAtCost><!--2-->
+                    </puf:TaxSubtotalExtension>
+                </puf:PageroExtension>
+            </ext:ExtensionContent>
+        </ext:UBLExtension>
+    </ext:UBLExtensions>
+    <cbc:TaxableAmount currencyID="EUR">1000.00</cbc:TaxableAmount>
+    <cbc:TaxAmount currencyID="EUR">210.00</cbc:TaxAmount>
+    <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.0</cbc:Percent>
+        <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+    </cac:TaxCategory>
+</cac:TaxSubtotal>
+----
+<1> Special regime key `06` - VAT group advanced level
+<2> Tax base at cost for special group regime calculation
+
+==== Related Resources
+
+* https://pagero.github.io/puf-code-lists/#_puf_003_invoicetypecode[PUF-003-INVOICETYPECODE^] - Invoice type codes
+* https://pagero.github.io/puf-code-lists/#_identification_scheme_spain[PUF-008-IDENTIFICATIONSCHEME (Spain)^] - Spanish identification schemes
+* https://pagero.github.io/puf-code-lists/#_puf_012_taxcategorycode[PUF-012-TAXCATEGORYCODE^] - Tax category codes
+* https://pagero.github.io/puf-code-lists/#_tax_exemption_codes_in_spain_verifactu[PUF-013-TAXEXEMPTIONCODE (Spain)^] - Tax exemption and no-subject codes
+* https://pagero.github.io/puf-code-lists/#_puf_022_specialregimekey[PUF-022-SPECIALREGIMEKEY^] - Special regime keys for Spanish tax operations

--- a/specification/extensions/document-level/BillingReferenceExtension.adoc
+++ b/specification/extensions/document-level/BillingReferenceExtension.adoc
@@ -48,6 +48,22 @@ Code signifying the reason for credit.
 |`puf:ClearanceID`
 |**Clearance ID of the referenced document** +
 ID, usually assigned by the Tax Authority, of the referenced document e.g. UUID in Malaysia.
+
+|`puf:RestrictedInformation`
+|**Restricted information** +
+Key-value pairs for additional country-specific information related to the billing reference. Can be repeated multiple times.
+
+|`cbc:TaxableAmount`
+|**Referenced document tax base amount** +
+The tax base amount of the referenced document. Used in some countries for corrections (e.g., Spain substitutive method).
+
+|`cbc:TaxAmount`
+|**Referenced document tax amount** +
+The tax amount of the referenced document. Used in some countries for corrections (e.g., Spain substitutive method).
+
+|`puf:EquivalenceSurchargeAmount`
+|**Referenced document equivalence surcharge amount** +
+The equivalence surcharge amount of the referenced document. Used in Spain for corrections when equivalence surcharge applies.
 |===
 
 *Example* +
@@ -72,6 +88,15 @@ _Invoice document reference ID, date and extension_
                                 <!-- Reason for credit in code form, if applicable -->
                                 <puf:Code>codeValue</puf:Code>
                                 <puf:ClearanceID>Clearance ID</puf:ClearanceID>
+                                <!-- Additional country-specific information, if applicable -->
+                                <puf:RestrictedInformation>
+                                    <puf:Key>CountrySpecificKey</puf:Key>
+                                    <puf:Value>CountrySpecificValue</puf:Value>
+                                </puf:RestrictedInformation>
+                                <!-- Referenced document amounts, if applicable (e.g., Spain substitutive corrections) -->
+                                <cbc:TaxableAmount currencyID="EUR">1000.00</cbc:TaxableAmount>
+                                <cbc:TaxAmount currencyID="EUR">210.00</cbc:TaxAmount>
+                                <puf:EquivalenceSurchargeAmount currencyID="EUR">52.00</puf:EquivalenceSurchargeAmount>
                             </puf:BillingReferenceExtension>
                         </puf:PageroExtension>
                     </ext:ExtensionContent>

--- a/specification/extensions/document-level/Simplified.adoc
+++ b/specification/extensions/document-level/Simplified.adoc
@@ -1,0 +1,64 @@
+This indicator can be used in conjunction with the regular invoice types to indicate if it is a simplified invoice, simplified credit note etc. +
+Please note that what is to be considered as simplified may vary between different countries (for example invoices below a certain amount etc).
+
+WARNING: Note that not all markets are supported in Pagero Online. +
+Please contact Pagero to learn in which markets we support simplified invoice in.
+
+The UBL extension to be used for below elements can be found <<_extublextensions, here>>.
+
+The structure used from `PUF-ExtensionComponent.xsd` is `PageroExtension/Simplified`. 
+
+See example below as well as the URI to be used for this extension.
+
+*Example* +
+[source,xml]
+----
+<Invoice>
+  <ext:UBLExtensions>
+      <ext:UBLExtension>
+          <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:Simplified</ext:ExtensionURI> <!--1-->
+          <ext:ExtensionContent>
+              <puf:PageroExtension>
+                <puf:Simplified/> <!--2-->
+              </puf:PageroExtension>
+          </ext:ExtensionContent>
+      </ext:UBLExtension>
+  </ext:UBLExtensions>
+  <!-- Code omitted for clarity -->
+</Invoice>
+----
+<1> URI to be used if this extension is added.
+<2> Structure to be used if information from this extension will be used.
+
+Below table shows the definition of the elements added to the extension.
+
+.Elements added to puf:PageroExtension/puf:Simplified
+|===
+|Element |Description
+
+|`puf:Simplified`
+|**Simplified Invoice Indicator** +
+Can either be *true* or *false*. +
+**Note that if the element is missing Pagero Online treat it as false**
+
+|===
+
+*Example* +
+_Simplified Invoice_
+[source,xml]
+----
+<Invoice>
+    <ext:UBLExtensions>
+        <ext:UBLExtension>
+            <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:Simplified</ext:ExtensionURI>
+            <ext:ExtensionContent>
+                <puf:PageroExtension>
+                    <puf:Simplified>true</puf:Simplified>
+                </puf:PageroExtension>
+            </ext:ExtensionContent>
+        </ext:UBLExtension>
+    </ext:UBLExtensions>
+    <!-- Code omitted for clarity -->
+</Invoice>
+
+----

--- a/specification/extensions/document-level/TaxSubTotalExtension.adoc
+++ b/specification/extensions/document-level/TaxSubTotalExtension.adoc
@@ -36,13 +36,26 @@ Below table lists all additional elements added to the extension.
 |===
 |Element |Description
 
+|`puf:SpecialRegimeKey`
+|**Special regime key** +
+Code identifying the special tax regime or transaction type. Mandatory in some countries (e.g., Spain VeriFactu ClaveRegimen). +
+For valid values see code list https://pagero.github.io/puf-code-lists/#_puf_022_specialregimekey[PUF-022-SPECIALREGIMEKEY^].
+
+|`puf:TaxBaseAtCost`
+|**Tax base at cost** +
+Tax base calculated at cost for special group regimes. Used in certain countries (e.g., Spain) for specific tax regime scenarios.
+
+|`puf:TaxBaseAtCost/@currencyID`
+|**Currency of TaxBaseAtCost** +
+For valid values see code list https://pagero.github.io/puf-code-lists/#_puf_004_currencycode[PUF-004-CURRENCYCODE^].
+
 |`puf:TaxCurrencyTaxableAmount`
 |**Tax currency taxable amount** +
 Taxable amount in tax currency per subtotal.
 
 |`puf:TaxCurrencyTaxableAmount/@currencyID`
 |**Tax currency taxable amount currency** +
-Currency of taxable amount in tax currency per subtotal.
+For valid values see code list https://pagero.github.io/puf-code-lists/#_puf_004_currencycode[PUF-004-CURRENCYCODE^].
 
 |`puf:TaxCurrencyTaxAmount`
 |**Tax currency tax amount** +
@@ -50,7 +63,7 @@ Tax amount in tax currency per subtotal.
 
 |`puf:TaxCurrencyTaxAmount/@currencyID`
 |**Tax currency tax amount currency** +
-Currency of tax amount in tax currency per subtotal.
+For valid values see code list https://pagero.github.io/puf-code-lists/#_puf_004_currencycode[PUF-004-CURRENCYCODE^].
 
 |`puf:TaxInclusiveAmount`
 |**Total amount including tax** +
@@ -71,6 +84,18 @@ For valid values see code list https://pagero.github.io/puf-code-lists/#_puf_004
 |`puf:TaxChargeability/cbc:TaxTypeCode`
 |**Tax chargeability** +
 Tax chargeability per tax (see Italy section <<_tax_chargeability_esigibilita_iva, here>>).
+
+|`puf:EquivalenceSurcharge/cbc:Percent`
+|**Equivalence surcharge percentage** +
+The percentage rate of the equivalence surcharge (Recargo de Equivalencia). Used in Spain for certain retail traders.
+
+|`puf:EquivalenceSurcharge/puf:Amount`
+|**Equivalence surcharge amount** +
+The amount of the equivalence surcharge (Recargo de Equivalencia). Used in Spain for certain retail traders.
+
+|`puf:EquivalenceSurcharge/puf:Amount/@currencyID`
+|**Currency of EquivalenceSurcharge Amount** +
+For valid values see code list https://pagero.github.io/puf-code-lists/#_puf_004_currencycode[PUF-004-CURRENCYCODE^].
 
 |===
 
@@ -164,3 +189,133 @@ See example below.
 <3> Taxable amount in tax currency for 12% rate.
 <4> Tax amount in tax currency for 12% rate.
 <5> Summary of all sub totals `TaxCurrencyTaxAmount`.
+
+===== Special regime key
+
+Some countries require a special regime key to classify the tax regime type or special transaction scheme. This is mandatory in certain jurisdictions (e.g., Spain VeriFactu).
+
+The special regime key is provided using `puf:SpecialRegimeKey` within the `TaxSubtotalExtension`.
+
+For a complete list of special regime keys, see https://pagero.github.io/puf-code-lists/#_puf_022_specialregimekey[PUF-022-SPECIALREGIMEKEY^].
+
+*Example*
+[source,xml]
+----
+<Invoice>
+  <!-- Code omitted for clarity -->
+  <cac:TaxTotal>
+      <cac:TaxSubtotal>
+          <ext:UBLExtensions>
+              <ext:UBLExtension>
+                  <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension</ext:ExtensionURI>
+                  <ext:ExtensionContent>
+                      <puf:PageroExtension>
+                          <puf:TaxSubtotalExtension>
+                              <puf:SpecialRegimeKey>01</puf:SpecialRegimeKey> <!--1-->
+                          </puf:TaxSubtotalExtension>
+                      </puf:PageroExtension>
+                  </ext:ExtensionContent>
+              </ext:UBLExtension>
+          </ext:UBLExtensions>
+          <cbc:TaxableAmount currencyID="EUR">1000.00</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">210.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+              <cbc:ID>S</cbc:ID>
+              <cbc:Percent>21.0</cbc:Percent>
+              <cac:TaxScheme>
+                  <cbc:ID>VAT</cbc:ID>
+              </cac:TaxScheme>
+          </cac:TaxCategory>
+      </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <!-- Code omitted for clarity -->
+</Invoice>
+----
+<1> Special regime key code (e.g., `01` for general regime in Spain).
+
+===== Equivalence surcharge
+
+The equivalence surcharge (Recargo de Equivalencia) is a special tax regime applicable to certain retail traders in Spain. When applicable, both the rate and amount must be provided.
+
+*Example*
+[source,xml]
+----
+<Invoice>
+  <!-- Code omitted for clarity -->
+  <cac:TaxTotal>
+      <cac:TaxSubtotal>
+          <ext:UBLExtensions>
+              <ext:UBLExtension>
+                  <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension</ext:ExtensionURI>
+                  <ext:ExtensionContent>
+                      <puf:PageroExtension>
+                          <puf:TaxSubtotalExtension>
+                              <puf:SpecialRegimeKey>18</puf:SpecialRegimeKey> <!--1-->
+                              <puf:EquivalenceSurcharge>
+                                  <cbc:Percent>5.2</cbc:Percent> <!--2-->
+                                  <puf:Amount currencyID="EUR">52.00</puf:Amount> <!--3-->
+                              </puf:EquivalenceSurcharge>
+                          </puf:TaxSubtotalExtension>
+                      </puf:PageroExtension>
+                  </ext:ExtensionContent>
+              </ext:UBLExtension>
+          </ext:UBLExtensions>
+          <cbc:TaxableAmount currencyID="EUR">1000.00</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">210.00</cbc:TaxAmount> <!--4-->
+          <cac:TaxCategory>
+              <cbc:ID>S</cbc:ID>
+              <cbc:Percent>21.0</cbc:Percent>
+              <cac:TaxScheme>
+                  <cbc:ID>VAT</cbc:ID>
+              </cac:TaxScheme>
+          </cac:TaxCategory>
+      </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <!-- Code omitted for clarity -->
+</Invoice>
+----
+<1> Special regime key `18` indicates equivalence surcharge applies.
+<2> Equivalence surcharge rate (5.2%).
+<3> Equivalence surcharge amount = 1000.00 × 5.2% = 52.00.
+<4> Tax amount (IVA) = 1000.00 × 21% = 210.00.
+
+===== Tax base at cost
+
+For special group regimes in certain countries (e.g., Spain), a tax base at cost may be required in addition to the standard taxable amount.
+
+*Example*
+[source,xml]
+----
+<Invoice>
+  <!-- Code omitted for clarity -->
+  <cac:TaxTotal>
+      <cac:TaxSubtotal>
+          <ext:UBLExtensions>
+              <ext:UBLExtension>
+                  <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension</ext:ExtensionURI>
+                  <ext:ExtensionContent>
+                      <puf:PageroExtension>
+                          <puf:TaxSubtotalExtension>
+                              <puf:SpecialRegimeKey>06</puf:SpecialRegimeKey> <!--1-->
+                              <puf:TaxBaseAtCost currencyID="EUR">800.00</puf:TaxBaseAtCost> <!--2-->
+                          </puf:TaxSubtotalExtension>
+                      </puf:PageroExtension>
+                  </ext:ExtensionContent>
+              </ext:UBLExtension>
+          </ext:UBLExtensions>
+          <cbc:TaxableAmount currencyID="EUR">1000.00</cbc:TaxableAmount>
+          <cbc:TaxAmount currencyID="EUR">210.00</cbc:TaxAmount>
+          <cac:TaxCategory>
+              <cbc:ID>S</cbc:ID>
+              <cbc:Percent>21.0</cbc:Percent>
+              <cac:TaxScheme>
+                  <cbc:ID>VAT</cbc:ID>
+              </cac:TaxScheme>
+          </cac:TaxCategory>
+      </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <!-- Code omitted for clarity -->
+</Invoice>
+----
+<1> Special regime key `06` - VAT group advanced level.
+<2> Tax base calculated at cost for the special group regime.

--- a/specification/extensions/extensions-document-level.adoc
+++ b/specification/extensions/extensions-document-level.adoc
@@ -19,13 +19,9 @@ include::document-level/RestrictedInformationLine.adoc[]
 
 include::document-level/Classification.adoc[]
 
-==== InvoiceSeries
+==== SupplierGeneratedQRString
 
-include::document-level/InvoiceSeries.adoc[]
-
-==== LanguageCode
-
-include::document-level/LanguageCode.adoc[]
+include::document-level/SupplierGeneratedQRString.adoc[]
 
 ==== SupplyType
 
@@ -37,19 +33,23 @@ include::document-level/DutyStamp.adoc[]
 
 ==== IGSTOnIntra
 
-include::document-level/IgstOnIntra.adoc[]
+include::document-level/IGSTOnIntra.adoc[]
 
 ==== Billing Software
 
 include::document-level/BillingSoftwareExtension.adoc[]
 
-==== SupplierGeneratedQRString
+==== InvoiceSeries
 
-include::document-level/SupplierGeneratedQRString.adoc[]
+include::document-level/InvoiceSeries.adoc[]
 
 ==== Self Billing Indicator
 
-include::document-level/SelfBilled.adoc[]
+include::document-level/Selfbilled.adoc[]
+
+==== Simplified Indicator
+
+include::document-level/Simplified.adoc[]
 
 ==== OrderReference
 
@@ -75,10 +75,6 @@ include::document-level/DeliveryExtension.adoc[]
 
 include::document-level/PaymentTermsExtension.adoc[]
 
-==== PrepaidPayment
-
-include::document-level/PrepaidPaymentExtension.adoc[]
-
 ==== TaxSubTotal
 
 include::document-level/TaxSubTotalExtension.adoc[]
@@ -86,3 +82,11 @@ include::document-level/TaxSubTotalExtension.adoc[]
 ==== LegalMonetaryTotal
 
 include::document-level/LegalMonetaryTotalExtension.adoc[]
+
+==== PrepaidPayment
+
+include::document-level/PrepaidPaymentExtension.adoc[]
+
+==== LanguageCode
+
+include::document-level/LanguageCode.adoc[]

--- a/specification/supported-countries.adoc
+++ b/specification/supported-countries.adoc
@@ -52,7 +52,7 @@ NOTE: The "Require ext:UBLExtensions"-column indicates whether or not the use of
 
 |Croatia
 |*Yes*
-|*No*
+|*Yes*
 |
 
 |Cyprus
@@ -175,6 +175,11 @@ NOTE: The "Require ext:UBLExtensions"-column indicates whether or not the use of
 |*No*
 |
 
+|Philippines
+|*Yes*
+|*Yes*
+|
+
 |Portugal
 |*Yes*
 |*Yes*
@@ -221,6 +226,12 @@ NOTE: The "Require ext:UBLExtensions"-column indicates whether or not the use of
 |Support for TicketBAI system in the Basque region. +
 Only support for invoice and credit.
 
+|Spain (VeriFactu)
+|*Yes*
+|*Yes*
+|Support for VeriFactu. +
+Only support for invoice and credit/correction.
+
 |Sweden
 |*Yes*
 |*No*
@@ -249,6 +260,6 @@ Only support for invoice and credit.
 |Vietnam
 |*Yes*
 |*Yes*
-|Only support for 'new' Invoice. See <<_limitations,limitations>> for more information.
+|Only support for 'new' Invoice.
 
 |===


### PR DESCRIPTION
Add examples and specifications

- Created README.md for Spain VeriFactu examples, detailing the structure and requirements for various invoice types including standard, simplified, and rectificative invoices.
- Added comprehensive specifications for Spain VeriFactu e-invoicing, covering invoice number, document types, correction methods, party identification, tax details, and special regime keys.
- Implemented documentation for the simplified invoice extension, outlining its usage and structure within the UBL framework.