### PR TITLE
France - Use schemeID 0225 for EndpointID in example files

### DIFF
--- a/examples/country-specific-examples/france/PUF_France_UC10_PostFactoring_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC10_PostFactoring_Invoice.xml
@@ -134,7 +134,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34: Seller electronic address -->
-            <cbc:EndpointID schemeID="0009">11122233344455</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">11122233344455</cbc:EndpointID>
 
             <!-- BT-28: Seller trading name -->
             <cac:PartyName>
@@ -176,7 +176,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- BT-49: Buyer electronic address -->
-            <cbc:EndpointID schemeID="0009">77788899900112</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">77788899900112</cbc:EndpointID>
 
             <!-- BT-45: Buyer trading name -->
             <cac:PartyName>

--- a/examples/country-specific-examples/france/PUF_France_UC11_ThirdPartyProcessing_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC11_ThirdPartyProcessing_Invoice.xml
@@ -125,7 +125,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34: Seller electronic address (SIRET) -->
-            <cbc:EndpointID schemeID="0009">22233344455566</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">22233344455566</cbc:EndpointID>
 
             <!-- BT-28: Seller trading name -->
             <cac:PartyName>

--- a/examples/country-specific-examples/france/PUF_France_UC11_ThirdPartyProcessing_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC11_ThirdPartyProcessing_Invoice.xml
@@ -178,7 +178,7 @@
                  
                  Third party created this address with BUYER's mandate authorization.
                  FNFE-MPE provides standard mandate template (www.fnfe-mpe.org). -->
-            <cbc:EndpointID schemeID="0002">456789012_CSPARA</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">456789012_CSPARA</cbc:EndpointID>
 
             <!-- BT-45: Buyer trading name -->
             <cac:PartyName>

--- a/examples/country-specific-examples/france/PUF_France_UC12_IntermediationService_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC12_IntermediationService_Invoice.xml
@@ -123,7 +123,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34: Seller electronic address (SIRET) -->
-            <cbc:EndpointID schemeID="0009">55566677788899</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">55566677788899</cbc:EndpointID>
 
             <!-- BT-28: Seller trading name -->
             <cac:PartyName>
@@ -168,7 +168,7 @@
                  This is a service invoice FROM intermediary TO buyer.
                  BT-49 uses BUYER's standard electronic address, NOT SIREN_ACHATTR format
                  (that format is only for routing main purchase invoices TO intermediary). -->
-            <cbc:EndpointID schemeID="0009">78901234500011</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">78901234500011</cbc:EndpointID>
 
             <!-- BT-45: Buyer trading name -->
             <cac:PartyName>

--- a/examples/country-specific-examples/france/PUF_France_UC12_MainInvoice_TransparentIntermediary.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC12_MainInvoice_TransparentIntermediary.xml
@@ -149,7 +149,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34: Seller electronic address (SIRET) -->
-            <cbc:EndpointID schemeID="0009">33344455566677</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">33344455566677</cbc:EndpointID>
 
             <!-- BT-28: Seller trading name -->
             <cac:PartyName>

--- a/examples/country-specific-examples/france/PUF_France_UC12_MainInvoice_TransparentIntermediary.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC12_MainInvoice_TransparentIntermediary.xml
@@ -205,7 +205,7 @@
                  
                  Under French VAT law, transparent intermediary acts "in name and on behalf"
                  of BUYER (commettant). BUYER is legal purchaser, intermediary is representative. -->
-            <cbc:EndpointID schemeID="0002">789012345_ACHATTR</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">789012345_ACHATTR</cbc:EndpointID>
 
             <!-- BT-45: Buyer trading name -->
             <cac:PartyName>

--- a/examples/country-specific-examples/france/PUF_France_UC13_SellerAgent_CoContractor_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC13_SellerAgent_CoContractor_Invoice.xml
@@ -115,7 +115,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34: Seller electronic address (SIRET) -->
-            <cbc:EndpointID schemeID="0009">44455566600011</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">44455566600011</cbc:EndpointID>
 
             <!-- BT-29: SIRET identifier -->
             <cac:PartyIdentification>
@@ -192,7 +192,7 @@
                 </ext:UBLExtensions>
 
                 <!-- SELLER AGENT Electronic Address -->
-                <cbc:EndpointID schemeID="0009">77788899900011</cbc:EndpointID>
+                <cbc:EndpointID schemeID="0225">77788899900011</cbc:EndpointID>
 
                 <!-- SELLER AGENT Trading Name -->
                 <cac:PartyName>
@@ -231,7 +231,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- BT-49: Buyer electronic address -->
-            <cbc:EndpointID schemeID="0009">33344455500022</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">33344455500022</cbc:EndpointID>
 
             <!-- BT-46: Buyer identifier (SIRET) -->
             <cac:PartyIdentification>

--- a/examples/country-specific-examples/france/PUF_France_UC14_BuyerAgent_SellerAgent_CoContractor_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC14_BuyerAgent_SellerAgent_CoContractor_Invoice.xml
@@ -133,7 +133,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34: Seller electronic address (SIRET) -->
-            <cbc:EndpointID schemeID="0009">11122233300011</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">11122233300011</cbc:EndpointID>
 
             <!-- BT-29: SIRET identifier -->
             <cac:PartyIdentification>
@@ -209,7 +209,7 @@
                 </ext:UBLExtensions>
 
                 <!-- SELLER AGENT Electronic Address -->
-                <cbc:EndpointID schemeID="0009">66677788800011</cbc:EndpointID>
+                <cbc:EndpointID schemeID="0225">66677788800011</cbc:EndpointID>
 
                 <!-- SELLER AGENT Trading Name -->
                 <cac:PartyName>
@@ -337,7 +337,7 @@
                 </ext:UBLExtensions>
 
                 <!-- BUYER AGENT Electronic Address -->
-                <cbc:EndpointID schemeID="0009">88899900011122</cbc:EndpointID>
+                <cbc:EndpointID schemeID="0225">88899900011122</cbc:EndpointID>
 
                 <!-- BUYER AGENT Trading Name -->
                 <cac:PartyName>

--- a/examples/country-specific-examples/france/PUF_France_UC14_BuyerAgent_SellerAgent_CoContractor_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC14_BuyerAgent_SellerAgent_CoContractor_Invoice.xml
@@ -256,7 +256,7 @@
 
                  SchemeID "0002" = SIREN-based addressing
                  Service code "_ACHATIT" = Routes to BUYER AGENT's PA-TR (Achat IT) -->
-            <cbc:EndpointID schemeID="0002">456789012_ACHATIT</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">456789012_ACHATIT</cbc:EndpointID>
 
             <!-- BT-46: Buyer identifier (SIRET) -->
             <cac:PartyIdentification>

--- a/examples/country-specific-examples/france/PUF_France_UC15_BuyerAgent_MediaBuying_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC15_BuyerAgent_MediaBuying_Invoice.xml
@@ -160,7 +160,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34: Seller electronic address (SIRET) -->
-            <cbc:EndpointID schemeID="0009">11122233344455</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">11122233344455</cbc:EndpointID>
 
             <!-- BT-28: Seller trading name -->
             <cac:PartyName>
@@ -300,7 +300,7 @@
                     </ext:UBLExtension>
                 </ext:UBLExtensions>
                 <!-- BUYER AGENT Electronic Address -->
-                <cbc:EndpointID schemeID="0009">99988877766655</cbc:EndpointID>
+                <cbc:EndpointID schemeID="0225">99988877766655</cbc:EndpointID>
 
                 <!-- BUYER AGENT Trading Name -->
                 <cac:PartyName>

--- a/examples/country-specific-examples/france/PUF_France_UC15_BuyerAgent_MediaBuying_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC15_BuyerAgent_MediaBuying_Invoice.xml
@@ -221,7 +221,7 @@
                  - Post lifecycle statuses
                  
                  BUYER accesses invoices via PA-TR or own PA acting as OD/SC. -->
-            <cbc:EndpointID schemeID="0002">234567890_ACHATPUB</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">234567890_ACHATPUB</cbc:EndpointID>
 
             <!-- BT-45: Buyer trading name -->
             <cac:PartyName>

--- a/examples/country-specific-examples/france/PUF_France_UC16_Disbursement_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC16_Disbursement_Invoice.xml
@@ -89,7 +89,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34 Seller electronic address (SIRET) -->
-            <cbc:EndpointID schemeID="0009">44455566677788</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">44455566677788</cbc:EndpointID>
             <!-- BT-29 Seller SIRET identifier -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">44455566677788</cbc:ID>
@@ -126,7 +126,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- BT-49 Buyer electronic address -->
-            <cbc:EndpointID schemeID="0009">77788899900011</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">77788899900011</cbc:EndpointID>
             <!-- BT-46 Buyer SIRET identifier -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">77788899900011</cbc:ID>

--- a/examples/country-specific-examples/france/PUF_France_UC17a_PaymentIntermediary_F1_Sale_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC17a_PaymentIntermediary_F1_Sale_Invoice.xml
@@ -114,7 +114,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34: Seller electronic address (SIRET) -->
-            <cbc:EndpointID schemeID="0009">22233344400011</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">22233344400011</cbc:EndpointID>
 
             <!-- BT-29: SIRET identifier -->
             <cac:PartyIdentification>
@@ -168,7 +168,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- BT-49: Buyer electronic address -->
-            <cbc:EndpointID schemeID="0009">33344455500022</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">33344455500022</cbc:EndpointID>
 
             <!-- BT-46: Buyer identifier (SIRET) -->
             <cac:PartyIdentification>

--- a/examples/country-specific-examples/france/PUF_France_UC17a_PaymentIntermediary_F2_ServiceFee_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC17a_PaymentIntermediary_F2_ServiceFee_Invoice.xml
@@ -107,7 +107,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34: Seller electronic address (SIRET) -->
-            <cbc:EndpointID schemeID="0009">55566677700011</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">55566677700011</cbc:EndpointID>
 
             <!-- BT-29: SIRET identifier -->
             <cac:PartyIdentification>
@@ -157,7 +157,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- BT-49: Buyer electronic address -->
-            <cbc:EndpointID schemeID="0009">22233344400011</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">22233344400011</cbc:EndpointID>
 
             <!-- BT-46: Buyer identifier (SIRET) -->
             <cac:PartyIdentification>

--- a/examples/country-specific-examples/france/PUF_France_UC17b_BillingMandate_F1_Sale_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC17b_BillingMandate_F1_Sale_Invoice.xml
@@ -121,7 +121,7 @@
                  In UC17b, BT-34 must be an address where the facturant has access
                  for receiving lifecycle statuses. Routes to marketplace's PA-T platform.
                  SchemeID "0009" = SIRET-based addressing -->
-            <cbc:EndpointID schemeID="0009">55566677700011</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">55566677700011</cbc:EndpointID>
 
             <!-- BT-29: SIRET identifier (SELLER's SIRET) -->
             <cac:PartyIdentification>
@@ -197,7 +197,7 @@
                     </ext:UBLExtensions>
 
                     <!-- Billing Mandatary Electronic Address -->
-                    <cbc:EndpointID schemeID="0009">55566677700011</cbc:EndpointID>
+                    <cbc:EndpointID schemeID="0225">55566677700011</cbc:EndpointID>
 
                     <!-- Billing Mandatary Trading Name -->
                     <cac:PartyName>
@@ -243,7 +243,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- BT-49: Buyer electronic address -->
-            <cbc:EndpointID schemeID="0009">33344455500022</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">33344455500022</cbc:EndpointID>
 
             <!-- BT-46: Buyer identifier (SIRET) -->
             <cac:PartyIdentification>

--- a/examples/country-specific-examples/france/PUF_France_UC17b_BillingMandate_F1_Sale_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC17b_BillingMandate_F1_Sale_Invoice.xml
@@ -120,7 +120,7 @@
             <!-- BT-34: Seller electronic address - ROUTES TO FACTURANT'S PA-T
                  In UC17b, BT-34 must be an address where the facturant has access
                  for receiving lifecycle statuses. Routes to marketplace's PA-T platform.
-                 SchemeID "0009" = SIRET-based addressing -->
+                 SchemeID "0225" = French electronic addressing scheme -->
             <cbc:EndpointID schemeID="0225">55566677700011</cbc:EndpointID>
 
             <!-- BT-29: SIRET identifier (SELLER's SIRET) -->

--- a/examples/country-specific-examples/france/PUF_France_UC19a_BillingAgent_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC19a_BillingAgent_Invoice.xml
@@ -166,7 +166,7 @@
                  Routes to Billing Agent's PA-E (88877766655544) for lifecycle status
                  reception and management. The Agent manages statuses on behalf of SELLER.
                  
-                 SchemeID "0002" = SIRET-based addressing
+                 SchemeID "0225" = French electronic addressing scheme
                  
                  Platform Option 1 (Used Here): SELLER and Agent share same PA-E
                  - Both parties access same platform and see same invoices/statuses
@@ -178,7 +178,7 @@
                  - Agent must transmit created invoice to SELLER after emission
                  - Agent must share all lifecycle statuses with SELLER
                  - SELLER informs Agent of payment collection -->
-            <cbc:EndpointID schemeID="0002">88877766655544</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">88877766655544</cbc:EndpointID>
 
             <!-- BT-27: Seller trading name -->
             <cac:PartyName>
@@ -259,7 +259,7 @@
                     </ext:UBLExtensions>
 
                     <!-- Billing Agent Electronic Address (Status Reception) -->
-                    <cbc:EndpointID schemeID="0002">88877766655544</cbc:EndpointID>
+                    <cbc:EndpointID schemeID="0225">88877766655544</cbc:EndpointID>
 
                     <!-- Billing Agent Trading Name -->
                     <cac:PartyName>
@@ -306,7 +306,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- BT-49: Buyer electronic address -->
-            <cbc:EndpointID schemeID="0002">11122233344455</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">11122233344455</cbc:EndpointID>
 
             <!-- BT-45: Buyer trading name -->
             <cac:PartyName>

--- a/examples/country-specific-examples/france/PUF_France_UC19b_SelfBilling_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC19b_SelfBilling_Invoice.xml
@@ -188,7 +188,7 @@
             <!-- BT-34: Seller electronic address
                  Routes to SELLER's PA-R (reception platform).
                  SELLER receives invoice here and creates treatment statuses. -->
-            <cbc:EndpointID schemeID="0002">77766655544433</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">77766655544433</cbc:EndpointID>
 
             <!-- BT-27: Seller trading name -->
             <cac:PartyName>
@@ -255,7 +255,7 @@
             <!-- BT-49: Buyer electronic address
                  Routes to BUYER's PA-E (emission platform).
                  BUYER creates and emits invoice from here. -->
-            <cbc:EndpointID schemeID="0002">99988877766655</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">99988877766655</cbc:EndpointID>
 
             <!-- BT-45: Buyer trading name -->
             <cac:PartyName>

--- a/examples/country-specific-examples/france/PUF_France_UC1_MultiOrder_MultiDelivery_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC1_MultiOrder_MultiDelivery_Invoice.xml
@@ -167,6 +167,8 @@
             <cac:PartyLegalEntity>
                 <!-- BT-44 Buyer Legal Name -->
                 <cbc:RegistrationName>Chaîne Magasins Retail France SA</cbc:RegistrationName>
+                <!-- BT-47 SIREN -->
+                <cbc:CompanyID schemeID="0002">987654321</cbc:CompanyID>
             </cac:PartyLegalEntity>
         </cac:Party>
     </cac:AccountingCustomerParty>

--- a/examples/country-specific-examples/france/PUF_France_UC1_MultiOrder_MultiDelivery_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC1_MultiOrder_MultiDelivery_Invoice.xml
@@ -84,7 +84,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34 Seller electronic address (mandatory for EXTENDED-CTC-FR) -->
-            <cbc:EndpointID schemeID="0009">12345678901234</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">12345678901234</cbc:EndpointID>
             <!-- BT-29 SIRET identifier -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">12345678901234</cbc:ID>
@@ -138,7 +138,7 @@
         <cbc:SupplierAssignedAccountID>CUST-FR-98765</cbc:SupplierAssignedAccountID>
         <cac:Party>
             <!-- BT-46 Buyer Identifier - SIRET -->
-            <cbc:EndpointID schemeID="0009">98765432109876</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">98765432109876</cbc:EndpointID>
             <!-- BT-45 Buyer Trading Name -->
             <cac:PartyName>
                 <cbc:Name>Chaîne Magasins Retail France</cbc:Name>

--- a/examples/country-specific-examples/france/PUF_France_UC20_PrepaymentInvoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC20_PrepaymentInvoice.xml
@@ -162,7 +162,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34: Seller electronic address -->
-            <cbc:EndpointID schemeID="0002">44455566677788</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">44455566677788</cbc:EndpointID>
 
             <!-- BT-27: Seller trading name -->
             <cac:PartyName>
@@ -216,7 +216,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- BT-49: Buyer electronic address -->
-            <cbc:EndpointID schemeID="0002">22233344455566</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">22233344455566</cbc:EndpointID>
 
             <!-- BT-45: Buyer trading name -->
             <cac:PartyName>

--- a/examples/country-specific-examples/france/PUF_France_UC21_FinalInvoiceAfterPrepayment.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC21_FinalInvoiceAfterPrepayment.xml
@@ -163,7 +163,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34: Seller electronic address -->
-            <cbc:EndpointID schemeID="0002">44455566677788</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">44455566677788</cbc:EndpointID>
 
             <!-- BT-27: Seller trading name -->
             <cac:PartyName>
@@ -217,7 +217,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- BT-49: Buyer electronic address -->
-            <cbc:EndpointID schemeID="0002">22233344455566</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">22233344455566</cbc:EndpointID>
 
             <!-- BT-45: Buyer trading name -->
             <cac:PartyName>

--- a/examples/country-specific-examples/france/PUF_France_UC22a_EarlyPaymentDiscount_Services_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC22a_EarlyPaymentDiscount_Services_Invoice.xml
@@ -78,7 +78,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34 Seller electronic address (mandatory for EXTENDED-CTC-FR) -->
-            <cbc:EndpointID schemeID="0009">45678901200015</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">45678901200015</cbc:EndpointID>
             <!-- BT-29 SIRET identifier (mandatory for French entities) -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">45678901200015</cbc:ID>
@@ -126,7 +126,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- BT-49 Buyer electronic address (mandatory for EXTENDED-CTC-FR) -->
-            <cbc:EndpointID schemeID="0009">12345678900034</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">12345678900034</cbc:EndpointID>
             <!-- BT-46 Buyer identifier -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">12345678900034</cbc:ID>

--- a/examples/country-specific-examples/france/PUF_France_UC22b_EarlyPaymentDiscount_CreditNote.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC22b_EarlyPaymentDiscount_CreditNote.xml
@@ -81,7 +81,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34 Seller electronic address (mandatory for EXTENDED-CTC-FR) -->
-            <cbc:EndpointID schemeID="0009">98765432100012</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">98765432100012</cbc:EndpointID>
             <!-- BT-29 SIRET identifier (mandatory for French entities) -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">98765432100012</cbc:ID>
@@ -129,7 +129,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- BT-49 Buyer electronic address (mandatory for EXTENDED-CTC-FR) -->
-            <cbc:EndpointID schemeID="0009">12345678900034</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">12345678900034</cbc:EndpointID>
             <!-- BT-46 Buyer identifier -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">12345678900034</cbc:ID>

--- a/examples/country-specific-examples/france/PUF_France_UC23_SelfBilling_FranchiseEnBase.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC23_SelfBilling_FranchiseEnBase.xml
@@ -98,7 +98,7 @@
                 BT-34 Seller electronic address.
                 Individual producers registered under SIREN use schemeID 0002.
             -->
-            <cbc:EndpointID schemeID="0002">444222111</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">444222111</cbc:EndpointID>
             <!-- BT-27 Seller name / individual name -->
             <cac:PartyName>
                 <cbc:Name>Jean-Pierre Beaumont</cbc:Name>

--- a/examples/country-specific-examples/france/PUF_France_UC23_SelfBilling_FranchiseEnBase.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC23_SelfBilling_FranchiseEnBase.xml
@@ -131,7 +131,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- BT-49 Buyer electronic address -->
-            <cbc:EndpointID schemeID="0009">88877766655544</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">88877766655544</cbc:EndpointID>
             <!-- BT-46 Buyer SIRET -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">88877766655544</cbc:ID>

--- a/examples/country-specific-examples/france/PUF_France_UC25_BUU_Sale_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC25_BUU_Sale_Invoice.xml
@@ -68,7 +68,7 @@
         <cac:Party>
             <!-- BT-29 SIRET identifier -->
             <!-- BT-34 Seller electronic address (mandatory for EXTENDED-CTC-FR) -->
-            <cbc:EndpointID schemeID="0009">56789012300018</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">56789012300018</cbc:EndpointID>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">56789012300018</cbc:ID>
             </cac:PartyIdentification>
@@ -110,7 +110,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- BT-49 Buyer electronic address (mandatory for EXTENDED-CTC-FR) -->
-            <cbc:EndpointID schemeID="0009">12345678900034</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">12345678900034</cbc:EndpointID>
             <!-- BT-46 Buyer identifier -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">12345678900034</cbc:ID>

--- a/examples/country-specific-examples/france/PUF_France_UC25_Redemption_SupplierToIssuer_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC25_Redemption_SupplierToIssuer_Invoice.xml
@@ -73,7 +73,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34 Seller electronic address (mandatory for EXTENDED-CTC-FR) -->
-            <cbc:EndpointID schemeID="0009">34567890100025</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">34567890100025</cbc:EndpointID>
             <!-- BT-29 SIRET identifier -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">34567890100025</cbc:ID>
@@ -118,7 +118,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- BT-49 Buyer electronic address (mandatory for EXTENDED-CTC-FR) -->
-            <cbc:EndpointID schemeID="0009">67890123400042</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">67890123400042</cbc:EndpointID>
             <!-- BT-46 Buyer identifier (ISSUER's SIRET) -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">67890123400042</cbc:ID>

--- a/examples/country-specific-examples/france/PUF_France_UC26_ReservationClause_CreditNote.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC26_ReservationClause_CreditNote.xml
@@ -66,7 +66,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34 Seller electronic address (mandatory for EXTENDED-CTC-FR) -->
-            <cbc:EndpointID schemeID="0009">23456789000030</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">23456789000030</cbc:EndpointID>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">23456789000030</cbc:ID>
             </cac:PartyIdentification>
@@ -104,7 +104,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- BT-49 Buyer electronic address (mandatory for EXTENDED-CTC-FR) -->
-            <cbc:EndpointID schemeID="0009">12345678900034</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">12345678900034</cbc:EndpointID>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">12345678900034</cbc:ID>
             </cac:PartyIdentification>

--- a/examples/country-specific-examples/france/PUF_France_UC26_ReservationClause_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC26_ReservationClause_Invoice.xml
@@ -84,7 +84,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34 Seller electronic address (mandatory for EXTENDED-CTC-FR) -->
-            <cbc:EndpointID schemeID="0009">23456789000030</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">23456789000030</cbc:EndpointID>
             <!-- BT-29 SIRET identifier -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">23456789000030</cbc:ID>
@@ -127,7 +127,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- BT-49 Buyer electronic address (mandatory for EXTENDED-CTC-FR) -->
-            <cbc:EndpointID schemeID="0009">12345678900034</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">12345678900034</cbc:EndpointID>
             <!-- BT-46 Buyer identifier -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">12345678900034</cbc:ID>

--- a/examples/country-specific-examples/france/PUF_France_UC29_SingleVATEntity_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC29_SingleVATEntity_Invoice.xml
@@ -93,7 +93,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34 Seller electronic address (member's own SIRET) -->
-            <cbc:EndpointID schemeID="0009">33344455566677</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">33344455566677</cbc:EndpointID>
 
             <!--
                 BT-29 identifiers — TWO entries required per G1.76:
@@ -153,7 +153,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- BT-49 Buyer electronic address (buyer's SIRET) -->
-            <cbc:EndpointID schemeID="0009">11122233344456</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">11122233344456</cbc:EndpointID>
             <!-- BT-46 Buyer SIRET -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">11122233344456</cbc:ID>

--- a/examples/country-specific-examples/france/PUF_France_UC2_AlreadyPaid_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC2_AlreadyPaid_Invoice.xml
@@ -144,7 +144,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34 Seller electronic address (mandatory for EXTENDED-CTC-FR) -->
-            <cbc:EndpointID schemeID="0009">45678901234567</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">45678901234567</cbc:EndpointID>
             <!-- BT-29 SIRET identifier -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">45678901234567</cbc:ID>
@@ -198,7 +198,7 @@
         <cbc:SupplierAssignedAccountID>CLIENT-BIO-5432</cbc:SupplierAssignedAccountID>
         <cac:Party>
             <!-- BT-46 Buyer Identifier - SIRET -->
-            <cbc:EndpointID schemeID="0009">12312312312312</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">12312312312312</cbc:EndpointID>
             <!-- BT-45 Buyer Trading Name -->
             <cac:PartyName>
                 <cbc:Name>Magasins Bio Nature France</cbc:Name>

--- a/examples/country-specific-examples/france/PUF_France_UC2_AlreadyPaid_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC2_AlreadyPaid_Invoice.xml
@@ -227,6 +227,8 @@
             <cac:PartyLegalEntity>
                 <!-- BT-44 Buyer Legal Name -->
                 <cbc:RegistrationName>Magasins Bio Nature France SA</cbc:RegistrationName>
+                <!-- BT-47 SIREN -->
+                <cbc:CompanyID schemeID="0002">123123123</cbc:CompanyID>
             </cac:PartyLegalEntity>
         </cac:Party>
     </cac:AccountingCustomerParty>

--- a/examples/country-specific-examples/france/PUF_France_UC30_VATAlreadyCollected.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC30_VATAlreadyCollected.xml
@@ -161,7 +161,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34: Seller electronic address -->
-            <cbc:EndpointID schemeID="0002">66677788899900</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">66677788899900</cbc:EndpointID>
 
             <!-- BT-27: Seller trading name -->
             <cac:PartyName>
@@ -213,7 +213,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- BT-49: Buyer electronic address -->
-            <cbc:EndpointID schemeID="0002">33344455566677</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">33344455566677</cbc:EndpointID>
 
             <!-- BT-45: Buyer trading name -->
             <cac:PartyName>

--- a/examples/country-specific-examples/france/PUF_France_UC31_MixedInvoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC31_MixedInvoice.xml
@@ -97,7 +97,7 @@
     <!-- BG-4 Seller — IndustriTech Solutions SARL -->
     <cac:AccountingSupplierParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0009">56789012311122</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">56789012311122</cbc:EndpointID>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">56789012311122</cbc:ID>
             </cac:PartyIdentification>
@@ -128,7 +128,7 @@
     <!-- BG-7 Buyer -->
     <cac:AccountingCustomerParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0009">22233344455566</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">22233344455566</cbc:EndpointID>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">22233344455566</cbc:ID>
             </cac:PartyIdentification>

--- a/examples/country-specific-examples/france/PUF_France_UC32a_MonthlyPayments_AdditionalDue.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC32a_MonthlyPayments_AdditionalDue.xml
@@ -144,7 +144,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34: Seller electronic address -->
-            <cbc:EndpointID schemeID="0002">22233344455566</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">22233344455566</cbc:EndpointID>
 
             <!-- BT-27: Seller trading name -->
             <cac:PartyName>

--- a/examples/country-specific-examples/france/PUF_France_UC32b_MonthlyPayments_CreditDue.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC32b_MonthlyPayments_CreditDue.xml
@@ -132,7 +132,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34: Seller electronic address -->
-            <cbc:EndpointID schemeID="0002">22233344455566</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">22233344455566</cbc:EndpointID>
 
             <!-- BT-27: Seller trading name -->
             <cac:PartyName>

--- a/examples/country-specific-examples/france/PUF_France_UC33_MarginScheme_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC33_MarginScheme_Invoice.xml
@@ -84,7 +84,7 @@
     <!-- BG-4 Seller — Second-hand vehicle dealer -->
     <cac:AccountingSupplierParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0009">65432198711100</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">65432198711100</cbc:EndpointID>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">65432198711100</cbc:ID>
             </cac:PartyIdentification>
@@ -115,7 +115,7 @@
     <!-- BG-7 Buyer — Fleet management company -->
     <cac:AccountingCustomerParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0009">31415926535897</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">31415926535897</cbc:EndpointID>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">31415926535897</cbc:ID>
             </cac:PartyIdentification>

--- a/examples/country-specific-examples/france/PUF_France_UC36_ProfessionalSecrecy_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC36_ProfessionalSecrecy_Invoice.xml
@@ -69,7 +69,7 @@
     <!-- BG-4 Seller — Law firm -->
     <cac:AccountingSupplierParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0009">21234567800019</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">21234567800019</cbc:EndpointID>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">21234567800019</cbc:ID>
             </cac:PartyIdentification>
@@ -100,7 +100,7 @@
     <!-- BG-7 Buyer — Pharmaceutical company -->
     <cac:AccountingCustomerParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0009">93827165049382</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">93827165049382</cbc:EndpointID>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">93827165049382</cbc:ID>
             </cac:PartyIdentification>

--- a/examples/country-specific-examples/france/PUF_France_UC37_Partnership_SEP_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC37_Partnership_SEP_Invoice.xml
@@ -95,7 +95,7 @@
     <!-- BG-4 Seller — Structural engineering firm -->
     <cac:AccountingSupplierParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0009">78901234511233</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">78901234511233</cbc:EndpointID>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">78901234511233</cbc:ID>
             </cac:PartyIdentification>

--- a/examples/country-specific-examples/france/PUF_France_UC3_ThirdPartyPayer_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC3_ThirdPartyPayer_Invoice.xml
@@ -60,7 +60,7 @@
                                 </ext:UBLExtension>
                             </ext:UBLExtensions>
                             <!-- EXT-FR-FE-52: Electronic address (RECOMMENDED) -->
-                            <cbc:EndpointID schemeID="0009">11122233344556</cbc:EndpointID>
+                            <cbc:EndpointID schemeID="0225">11122233344556</cbc:EndpointID>
                             <!-- EXT-FR-FE-46: PAYER party identification (SIRET) -->
                             <cac:PartyIdentification>
                                 <cbc:ID schemeID="0009">11122233344556</cbc:ID>
@@ -153,7 +153,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34 Seller electronic address (mandatory for EXTENDED-CTC-FR) -->
-            <cbc:EndpointID schemeID="0009">12345678901234</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">12345678901234</cbc:EndpointID>
             <!-- BT-29 SIRET identifier -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">12345678901234</cbc:ID>
@@ -207,7 +207,7 @@
         <cbc:SupplierAssignedAccountID>CLIENT-MAG-5678</cbc:SupplierAssignedAccountID>
         <cac:Party>
             <!-- BT-46 Buyer Identifier - SIRET -->
-            <cbc:EndpointID schemeID="0009">55566677788990</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">55566677788990</cbc:EndpointID>
             <!-- BT-45 Buyer Trading Name -->
             <cac:PartyName>
                 <cbc:Name>Magasin Retail Paris Centre</cbc:Name>

--- a/examples/country-specific-examples/france/PUF_France_UC3_ThirdPartyPayer_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC3_ThirdPartyPayer_Invoice.xml
@@ -236,6 +236,8 @@
             <cac:PartyLegalEntity>
                 <!-- BT-44 Buyer Legal Name -->
                 <cbc:RegistrationName>Magasin Retail Paris Centre SARL</cbc:RegistrationName>
+                <!-- BT-47 SIREN -->
+                <cbc:CompanyID schemeID="0002">555666777</cbc:CompanyID>
             </cac:PartyLegalEntity>
         </cac:Party>
     </cac:AccountingCustomerParty>

--- a/examples/country-specific-examples/france/PUF_France_UC40_Netting_Invoice1_CoopToFarmer.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC40_Netting_Invoice1_CoopToFarmer.xml
@@ -169,7 +169,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34: Seller electronic address -->
-            <cbc:EndpointID schemeID="0002">11122233344455</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">11122233344455</cbc:EndpointID>
 
             <!-- BT-27: Seller trading name -->
             <cac:PartyName>
@@ -223,7 +223,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- BT-49: Buyer electronic address -->
-            <cbc:EndpointID schemeID="0002">55566677788899</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">55566677788899</cbc:EndpointID>
 
             <!-- BT-45: Buyer trading name -->
             <cac:PartyName>

--- a/examples/country-specific-examples/france/PUF_France_UC40_Netting_Invoice2_FarmerToCoop.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC40_Netting_Invoice2_FarmerToCoop.xml
@@ -160,7 +160,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34: Seller electronic address -->
-            <cbc:EndpointID schemeID="0002">55566677788899</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">55566677788899</cbc:EndpointID>
 
             <!-- BT-27: Seller trading name -->
             <cac:PartyName>
@@ -214,7 +214,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- BT-49: Buyer electronic address -->
-            <cbc:EndpointID schemeID="0002">11122233344455</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">11122233344455</cbc:EndpointID>
 
             <!-- BT-45: Buyer trading name -->
             <cac:PartyName>

--- a/examples/country-specific-examples/france/PUF_France_UC41_Barter_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC41_Barter_Invoice.xml
@@ -95,7 +95,7 @@
     <!-- BG-4 Seller — Advertising agency -->
     <cac:AccountingSupplierParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0009">56789012311200</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">56789012311200</cbc:EndpointID>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">56789012311200</cbc:ID>
             </cac:PartyIdentification>
@@ -126,7 +126,7 @@
     <!-- BG-7 Buyer — Barter intermediary company -->
     <cac:AccountingCustomerParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0009">34567890199011</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">34567890199011</cbc:EndpointID>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">34567890199011</cbc:ID>
             </cac:PartyIdentification>

--- a/examples/country-specific-examples/france/PUF_France_UC42_TaxFree_Scenario3_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC42_TaxFree_Scenario3_Invoice.xml
@@ -106,7 +106,7 @@
     <!-- BG-4 Seller — French luxury goods merchant -->
     <cac:AccountingSupplierParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0009">12345678900015</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">12345678900015</cbc:EndpointID>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">12345678900015</cbc:ID>
             </cac:PartyIdentification>
@@ -137,7 +137,7 @@
     <!-- BG-7 Buyer — Detax operator -->
     <cac:AccountingCustomerParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0009">98765432100123</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">98765432100123</cbc:EndpointID>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">98765432100123</cbc:ID>
             </cac:PartyIdentification>

--- a/examples/country-specific-examples/france/PUF_France_UC4_PartialThirdPartyPayment_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC4_PartialThirdPartyPayment_Invoice.xml
@@ -65,7 +65,7 @@
                                 </ext:UBLExtension>
                             </ext:UBLExtensions>
                             <!-- EXT-FR-FE-52: Electronic address (RECOMMENDED) -->
-                            <cbc:EndpointID schemeID="0009">77788899900112</cbc:EndpointID>
+                            <cbc:EndpointID schemeID="0225">77788899900112</cbc:EndpointID>
                             <!-- EXT-FR-FE-46: PAYER party identification (SIRET) -->
                             <cac:PartyIdentification>
                                 <cbc:ID schemeID="0009">77788899900112</cbc:ID>
@@ -151,7 +151,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34 Seller electronic address (mandatory for EXTENDED-CTC-FR) -->
-            <cbc:EndpointID schemeID="0009">98765432109876</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">98765432109876</cbc:EndpointID>
             <!-- BT-29 SIRET identifier -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">98765432109876</cbc:ID>
@@ -205,7 +205,7 @@
         <cbc:SupplierAssignedAccountID>CLIENT-AUTO-3456</cbc:SupplierAssignedAccountID>
         <cac:Party>
             <!-- BT-46 Buyer Identifier - SIRET -->
-            <cbc:EndpointID schemeID="0009">33344455566778</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">33344455566778</cbc:EndpointID>
             <!-- BT-45 Buyer Trading Name -->
             <cac:PartyName>
                 <cbc:Name>Transport Express Rhône SARL</cbc:Name>

--- a/examples/country-specific-examples/france/PUF_France_UC4_PartialThirdPartyPayment_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC4_PartialThirdPartyPayment_Invoice.xml
@@ -234,6 +234,8 @@
             <cac:PartyLegalEntity>
                 <!-- BT-44 Buyer Legal Name -->
                 <cbc:RegistrationName>Transport Express Rhône SARL</cbc:RegistrationName>
+                <!-- BT-47 SIREN -->
+                <cbc:CompanyID schemeID="0002">333444555</cbc:CompanyID>
             </cac:PartyLegalEntity>
             <!-- BG-9 Buyer Contact -->
             <cac:Contact>

--- a/examples/country-specific-examples/france/PUF_France_UC5_EmployeeExpense_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC5_EmployeeExpense_Invoice.xml
@@ -180,7 +180,7 @@
         <cbc:SupplierAssignedAccountID>ENTREPRISE-3456</cbc:SupplierAssignedAccountID>
         <cac:Party>
             <!-- BT-49 Buyer electronic address - Special routing for employee expenses -->
-            <cbc:EndpointID schemeID="0002">333444555_FRAISCOLLABORATEUR</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">333444555_FRAISCOLLABORATEUR</cbc:EndpointID>
             <!-- BT-46 Buyer Identifier - SIRET -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">33344455566778</cbc:ID>

--- a/examples/country-specific-examples/france/PUF_France_UC5_EmployeeExpense_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC5_EmployeeExpense_Invoice.xml
@@ -127,7 +127,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34 Seller electronic address (endpoint for e-invoicing) -->
-            <cbc:EndpointID schemeID="0009">12345678901234</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">12345678901234</cbc:EndpointID>
             <!-- BT-29 SIRET identifier -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">12345678901234</cbc:ID>

--- a/examples/country-specific-examples/france/PUF_France_UC7_CorporateCard_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC7_CorporateCard_Invoice.xml
@@ -82,7 +82,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34 Seller electronic address (endpoint for e-invoicing) -->
-            <cbc:EndpointID schemeID="0009">55566677788990</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">55566677788990</cbc:EndpointID>
             <!-- BT-29 SIRET identifier -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">55566677788990</cbc:ID>
@@ -135,7 +135,7 @@
         <cbc:SupplierAssignedAccountID>ENTREPRISE-7890</cbc:SupplierAssignedAccountID>
         <cac:Party>
             <!-- BT-49 Buyer electronic address -->
-            <cbc:EndpointID schemeID="0009">33344455566778</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">33344455566778</cbc:EndpointID>
             <!-- BT-46 Buyer Identifier - SIRET -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">33344455566778</cbc:ID>

--- a/examples/country-specific-examples/france/PUF_France_UC8_Factoring_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC8_Factoring_Invoice.xml
@@ -91,7 +91,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34 Seller electronic address (endpoint for e-invoicing) -->
-            <cbc:EndpointID schemeID="0009">78912345678901</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">78912345678901</cbc:EndpointID>
             <!-- BT-29 SIRET identifier -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">78912345678901</cbc:ID>
@@ -145,7 +145,7 @@
         <cbc:SupplierAssignedAccountID>CLIENT-IND-5678</cbc:SupplierAssignedAccountID>
         <cac:Party>
             <!-- BT-49 Buyer electronic address -->
-            <cbc:EndpointID schemeID="0009">44455566677889</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">44455566677889</cbc:EndpointID>
             <!-- BT-46 Buyer Identifier - SIRET -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">44455566677889</cbc:ID>
@@ -210,7 +210,7 @@
             </ext:UBLExtension>
         </ext:UBLExtensions>
         <!-- EXT-FR-FE-29 Payee electronic address (mandatory for EXTENDED-CTC-FR/Flux2) -->
-        <cbc:EndpointID schemeID="0009">22233344455667</cbc:EndpointID>
+        <cbc:EndpointID schemeID="0225">22233344455667</cbc:EndpointID>
         <!-- BT-60 Payee identifier (SIRET) -->
         <cac:PartyIdentification>
             <cbc:ID schemeID="0009">22233344455667</cbc:ID>

--- a/examples/country-specific-examples/france/PUF_France_UC9_Distributor_Invoice.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC9_Distributor_Invoice.xml
@@ -95,7 +95,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- BT-34 Seller electronic address (endpoint for e-invoicing) -->
-            <cbc:EndpointID schemeID="0009">56789012345678</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">56789012345678</cbc:EndpointID>
             <!-- BT-29 SIRET identifier -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">56789012345678</cbc:ID>
@@ -149,7 +149,7 @@
         <cbc:SupplierAssignedAccountID>CLIENT-ENT-7890</cbc:SupplierAssignedAccountID>
         <cac:Party>
             <!-- BT-49 Buyer electronic address -->
-            <cbc:EndpointID schemeID="0009">88899900011223</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0225">88899900011223</cbc:EndpointID>
             <!-- BT-46 Buyer Identifier - SIRET -->
             <cac:PartyIdentification>
                 <cbc:ID schemeID="0009">88899900011223</cbc:ID>
@@ -214,7 +214,7 @@
             </ext:UBLExtension>
         </ext:UBLExtensions>
         <!-- EXT-FR-FE-29 Payee electronic address (mandatory for EXTENDED-CTC-FR/Flux2) -->
-        <cbc:EndpointID schemeID="0009">33344455566778</cbc:EndpointID>
+        <cbc:EndpointID schemeID="0225">33344455566778</cbc:EndpointID>
         <!-- BT-60 Payee identifier (SIRET) -->
         <cac:PartyIdentification>
             <cbc:ID schemeID="0009">33344455566778</cbc:ID>


### PR DESCRIPTION
## Summary

Aligns the French example files with the official French CTC validation rules (FNFE **BR-FR-CTC Flux 2 Schematron V1.3.1**, 2026-04-30) and the AFNOR XP Z12-012/Z12-014 specifications.

### Commit 1 — EndpointID schemeID 0009 → 0225

33 files used `schemeID="0009"` (SIRET) on `cbc:EndpointID`. All 68 occurrences changed to `schemeID="0225"`, values unchanged. `schemeID="0009"` in `cac:PartyIdentification/cbc:ID` (SIRET as party identifier) is correct and untouched.

### Commit 2 — Remaining endpoint schemes + missing buyer SIREN

- Converted the remaining 23 `cbc:EndpointID schemeID="0002"` occurrences to `0225` (15 files).
- Added the missing buyer SIREN (`cac:PartyLegalEntity/cbc:CompanyID schemeID="0002"`) in UC1–UC4, derived from the buyer SIRET endpoint.
- Fixed two stale XML comments (UC17b, UC19a) still describing the old addressing scheme.

## Proof (authoritative sources)

| Rule | Requirement |
|---|---|
| **BR-FR-21/BT-49** | For `#BAR#B2B` treatment (non-self-billed), buyer `cbc:EndpointID` **schemeID must equal "0225"** and the value must start with the buyer SIREN (`CompanyID[@schemeID='0002']`) |
| **BR-FR-22/BT-34** | Same for the seller endpoint on self-billed documents (389, 501, 500, 471, 473, 261, 502) |
| **BR-FR-11/BT-47** | Buyer SIREN (`CompanyID[@schemeID='0002']`, 9 digits) is **mandatory** for `#BAR#B2B` — UC1–UC4 were missing it |
| **BR-FR-23/25** | 0225 endpoint format: alphanumeric + `-`, `_`, `.`; max 125 chars |

Additionally, **all 42 `cbc:EndpointID` occurrences in the official AFNOR XP Z12-014 V1.3 worked examples use schemeID 0225** — none use 0002 or 0009.

## Verification

- All 56 French example files remain well-formed XML.
- All 92 supplier/customer endpoints now use schemeID 0225; all parties carry a SIREN; 90/92 endpoint values start with the party''s own SIREN. The two exceptions (UC17b, UC19a seller endpoints) intentionally route to the billing agent''s electronic address, documented in the file comments, and are not governed by BR-FR-21/22 (type 380).

🤖 Generated with [Claude Code](https://claude.com/claude-code)