### PR TITLE
UAE: item type (BTAE-13) via cbc:CommodityCode

### DIFF
--- a/examples/country-specific-examples/uae/PUF_AE_CreditNote.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_CreditNote.xml
@@ -118,21 +118,10 @@
             <cbc:TaxAmount currencyID="AED">10.00</cbc:TaxAmount>
         </cac:TaxTotal>
         <cac:Item>
-            <ext:UBLExtensions>
-                <ext:UBLExtension>
-                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ItemExtension</ext:ExtensionURI>
-                    <ext:ExtensionContent>
-                        <puf:PageroExtension>
-                            <puf:ItemExtension>
-                                <puf:ItemType>GOODS</puf:ItemType>
-                            </puf:ItemExtension>
-                        </puf:PageroExtension>
-                    </ext:ExtensionContent>
-                </ext:UBLExtension>
-            </ext:UBLExtensions>
-        <cbc:Description>Industrial-grade centrifugal water pump, 5HP — 2 units returned</cbc:Description>
+            <cbc:Description>Industrial-grade centrifugal water pump, 5HP — 2 units returned</cbc:Description>
             <cbc:Name>Industrial pump</cbc:Name>
             <cac:CommodityClassification>
+                <cbc:CommodityCode>G</cbc:CommodityCode>
                 <cbc:ItemClassificationCode listID="HS">8413.70.10</cbc:ItemClassificationCode>
             </cac:CommodityClassification>
             <cac:ClassifiedTaxCategory>

--- a/examples/country-specific-examples/uae/PUF_AE_CreditNote.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_CreditNote.xml
@@ -1,4 +1,34 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+    PUF Credit Note Example: Standard Tax Credit Note
+
+    Use Case: A tax credit note correcting a previously issued tax invoice after the buyer
+              returned part of the delivered goods. Shows the UAE-specific credit note
+              reason code and the mandatory reference to the preceding invoice.
+
+    Country: United Arab Emirates
+    Format: PUF (Pagero Universal Format) 2.0
+    Document Type: Tax Credit Note (Type 381)
+    Transaction Type: BTAE-02 = 00000000 (no special transaction context)
+    Target Format: Peppol PINT BIS Billing AE 1.0.4
+
+    Scenario Description:
+    Burj Holdings PJSC returned 2 of the 10 industrial pumps invoiced on INV-AE-2026-00001.
+    Acme Trading LLC issues this credit note for AED 200.00 net plus AED 10.00 VAT,
+    crediting AED 210.00.
+
+    Key Fields:
+    - BT-3 CreditNoteTypeCode 381; BTAE-02 carried in @name exactly as on an invoice
+    - BTAE-03 Credit note reason code: mandatory for type 381 (ibr-158-ae). Carried in
+      puf:BillingReferenceExtension/puf:Code. Value DL8.61.1.D = goods or services returned
+    - BG-3 BillingReference: mandatory for a credit note unless the reason code is VD
+      (volume discount) - ibr-055-ae. Points at INV-AE-2026-00001 with its issue date
+    - BT-129 Quantity uses cbc:CreditedQuantity, not cbc:InvoicedQuantity
+    - No BT-9 due date: a credit note is excluded from the payment due date rule (ibr-127-ae)
+
+    Reference: UAE Electronic Invoicing Guidelines V1.1 (1 June 2026);
+               Peppol PINT BIS Billing AE 1.0.4
+-->
 <CreditNote xmlns:cac="urn:pagero:CommonAggregateComponents:1.0" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:puf="urn:pagero:ExtensionComponent:1.0" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns="urn:pagero:PageroUniversalFormat:CreditNote:1.0">
     <cbc:CustomizationID>urn:pagero.com:puf:billing:2.0</cbc:CustomizationID>
     <cbc:ProfileID>urn:pagero.com:puf:billing:1.0</cbc:ProfileID>
@@ -36,7 +66,7 @@
     </cac:BillingReference>
     <cac:AccountingSupplierParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0235">100000000000003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000000</cbc:EndpointID>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="AE:LRA">Department of Economic Development - Dubai</cbc:ID>
             </cac:PartyIdentification>
@@ -63,7 +93,7 @@
     </cac:AccountingSupplierParty>
     <cac:AccountingCustomerParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0235">100000000001003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000100</cbc:EndpointID>
             <cac:PartyIdentification>
                 <cbc:ID schemeID="AE:LRA">Abu Dhabi Department of Economic Development</cbc:ID>
             </cac:PartyIdentification>
@@ -77,7 +107,7 @@
             </cac:PostalAddress>
             <cac:PartyTaxScheme>
                 <!-- BT-48 Buyer TRN (15 digits, starts with 1, ends with 03) -->
-                <cbc:CompanyID>100000000001003</cbc:CompanyID>
+                <cbc:CompanyID>100000010001003</cbc:CompanyID>
                 <cac:TaxScheme>
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
@@ -131,7 +161,7 @@
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
             </cac:ClassifiedTaxCategory>
-            </cac:Item>
+        </cac:Item>
         <cac:Price>
             <cbc:PriceAmount currencyID="AED">100.00</cbc:PriceAmount>
             <cbc:BaseQuantity unitCode="EA">1</cbc:BaseQuantity>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice.xml
@@ -1,4 +1,36 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+    PUF Invoice Example: Standard Tax Invoice
+
+    Use Case: A plain domestic B2B tax invoice between two VAT-registered UAE businesses,
+              with no special transaction context. This is the baseline example - every
+              other UAE example in this folder is this invoice plus one scenario feature.
+
+    Country: United Arab Emirates
+    Format: PUF (Pagero Universal Format) 2.0
+    Document Type: Tax Invoice (Type 380)
+    Transaction Type: BTAE-02 = 00000000 (no special transaction context)
+    Target Format: Peppol PINT BIS Billing AE 1.0.4
+
+    Scenario Description:
+    Acme Trading LLC (Dubai) sells 10 industrial water pumps to Burj Holdings PJSC
+    (Abu Dhabi) for AED 100.00 each. The supply is standard rated at 5% VAT, giving
+    AED 1,000.00 net, AED 50.00 VAT and AED 1,050.00 payable within 30 days.
+
+    Key Fields:
+    - BT-34 / BT-49 Electronic addresses: the 10-digit TIN under Peppol scheme 0235
+      (the TIN is the first 10 digits of the 15-character TRN - do not use the TRN here)
+    - BT-31 / BT-48 TRN: 15 digits, starts with 1, ends with 03 (ibr-132-ae)
+    - BT-30 Legal registration identifier: trade license with @schemeID="AE:TL"
+    - BTAE-12 / BTAE-11 Authority name: mandatory for a trade license (ibr-172-ae, ibr-101-ae)
+    - BT-39 / BT-54 Emirate code: DXB, AUH (ibr-128-ae)
+    - BTAE-13 Item type: G (Goods), with HS classification (ibr-184-ae, ibr-188-ae)
+    - IBT-148 Item gross price: mandatory, here equal to net price (ibr-126-ae)
+    - BTAE-08 / BTAE-10 Line VAT and line amount in AED (ibr-104-ae, ibr-194-ae)
+
+    Reference: UAE Electronic Invoicing Guidelines V1.1 (1 June 2026);
+               Peppol PINT BIS Billing AE 1.0.4
+-->
 <Invoice xmlns:cac="urn:pagero:CommonAggregateComponents:1.0" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:puf="urn:pagero:ExtensionComponent:1.0" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns="urn:pagero:PageroUniversalFormat:Invoice:1.0">
     <cbc:CustomizationID>urn:pagero.com:puf:billing:2.0</cbc:CustomizationID>
     <cbc:ProfileID>urn:pagero.com:puf:billing:1.0</cbc:ProfileID>
@@ -14,8 +46,8 @@
     <cbc:DocumentCurrencyCode>AED</cbc:DocumentCurrencyCode>
     <cac:AccountingSupplierParty>
         <cac:Party>
-            <!-- BT-34 Seller electronic address. UAE TRN-as-routing-id uses Peppol scheme 0235 -->
-            <cbc:EndpointID schemeID="0235">100000000000003</cbc:EndpointID>
+            <!-- BT-34 Seller electronic address. The Peppol Participant Identifier is the 10-digit TIN (first 10 digits of the TRN) under scheme 0235 -->
+            <cbc:EndpointID schemeID="0235">1000000000</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-12 Seller legal registration authority (issuer of the trade license) -->
                 <cbc:ID schemeID="AE:LRA">Department of Economic Development - Dubai</cbc:ID>
@@ -53,7 +85,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- BT-49 Buyer electronic address -->
-            <cbc:EndpointID schemeID="0235">100000000001003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000100</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-11 Buyer legal registration authority -->
                 <cbc:ID schemeID="AE:LRA">Abu Dhabi Department of Economic Development</cbc:ID>
@@ -72,7 +104,7 @@
             </cac:PostalAddress>
             <cac:PartyTaxScheme>
                 <!-- BT-48 Buyer VAT identifier -->
-                <cbc:CompanyID>100000000001003</cbc:CompanyID>
+                <cbc:CompanyID>100000010001003</cbc:CompanyID>
                 <cac:TaxScheme>
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
@@ -158,7 +190,7 @@
             <!-- BT-158 Item classification code with BT-158-1 scheme (UAE requires HS for goods) -->
             <!-- BTAE-13 Item type (G goods / S services / B both).
                  Carried via cac:CommodityClassification/cbc:CommodityCode -->
-            </cac:Item>
+        </cac:Item>
         <cac:Price>
             <!-- BT-146 Item net price -->
             <cbc:PriceAmount currencyID="AED">100.00</cbc:PriceAmount>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice.xml
@@ -138,21 +138,10 @@
             <cbc:TaxAmount currencyID="AED">50.00</cbc:TaxAmount>
         </cac:TaxTotal>
         <cac:Item>
-            <ext:UBLExtensions>
-                <ext:UBLExtension>
-                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ItemExtension</ext:ExtensionURI>
-                    <ext:ExtensionContent>
-                        <puf:PageroExtension>
-                            <puf:ItemExtension>
-                                <puf:ItemType>GOODS</puf:ItemType>
-                            </puf:ItemExtension>
-                        </puf:PageroExtension>
-                    </ext:ExtensionContent>
-                </ext:UBLExtension>
-            </ext:UBLExtensions>
-        <cbc:Description>Industrial-grade centrifugal water pump, 5HP</cbc:Description>
+            <cbc:Description>Industrial-grade centrifugal water pump, 5HP</cbc:Description>
             <cbc:Name>Industrial pump</cbc:Name>
             <cac:CommodityClassification>
+                <cbc:CommodityCode>G</cbc:CommodityCode>
                 <cbc:ItemClassificationCode listID="HS">8413.70.10</cbc:ItemClassificationCode>
             </cac:CommodityClassification>
             <cac:ClassifiedTaxCategory>
@@ -167,8 +156,8 @@
             <!-- BT-154 Item description (mandatory in UAE per ibr-125-ae) -->
             <!-- BT-153 Item name -->
             <!-- BT-158 Item classification code with BT-158-1 scheme (UAE requires HS for goods) -->
-            <!-- BTAE-13 Item type (GOODS / SERVICES / BOTH).
-                 Carried via puf:ItemExtension/puf:ItemType -->
+            <!-- BTAE-13 Item type (G goods / S services / B both).
+                 Carried via cac:CommodityClassification/cbc:CommodityCode -->
             </cac:Item>
         <cac:Price>
             <!-- BT-146 Item net price -->

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_AdvancePayment.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_AdvancePayment.xml
@@ -154,25 +154,14 @@
             <cbc:TaxAmount currencyID="AED">450.00</cbc:TaxAmount>
         </cac:TaxTotal>
         <cac:Item>
-            <ext:UBLExtensions>
-                <ext:UBLExtension>
-                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ItemExtension</ext:ExtensionURI>
-                    <ext:ExtensionContent>
-                        <puf:PageroExtension>
-                            <puf:ItemExtension>
-                                <!-- BTAE-13 Item type (GOODS / SERVICES / BOTH) -->
-                                <puf:ItemType>GOODS</puf:ItemType>
-                            </puf:ItemExtension>
-                        </puf:PageroExtension>
-                    </ext:ExtensionContent>
-                </ext:UBLExtension>
-            </ext:UBLExtensions>
             <!-- BT-154 Item description (mandatory in UAE per ibr-125-ae) -->
             <cbc:Description>Custom-fabricated steel storage tank, 20,000 L — final balance after advance payment</cbc:Description>
             <!-- BT-153 Item name -->
             <cbc:Name>Steel storage tank</cbc:Name>
+            <!-- BTAE-13 Item type (G goods / S services / B both) carried via cac:CommodityClassification/cbc:CommodityCode -->
             <!-- BT-158 Item classification code (UAE requires HS for goods) -->
             <cac:CommodityClassification>
+                <cbc:CommodityCode>G</cbc:CommodityCode>
                 <cbc:ItemClassificationCode listID="HS">7309.00.00</cbc:ItemClassificationCode>
             </cac:CommodityClassification>
             <cac:ClassifiedTaxCategory>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_AdvancePayment.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_AdvancePayment.xml
@@ -1,4 +1,47 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+    PUF Invoice Example: Advance Payment - Final Invoice
+
+    Use Case: The final invoice issued after an advance payment was received and already
+              invoiced. UAE has no dedicated prepayment document type: both the advance
+              and the final invoice are ordinary Tax Invoices (380).
+
+    Country: United Arab Emirates
+    Format: PUF (Pagero Universal Format) 2.0
+    Document Type: Tax Invoice (Type 380)
+    Transaction Type: BTAE-02 = 00000000 (there is no advance or prepayment flag)
+    Target Format: Peppol PINT BIS Billing AE 1.0.4
+
+    Scenario Description:
+    This example follows the worked example in Appendix 5 of the Guidelines. Acme Trading
+    LLC contracted with Burj Holdings PJSC for AED 10,000.00 plus 5% VAT. An advance of
+    AED 1,000.00 plus VAT was received and invoiced as ADV-001 on 2026-05-01. This final
+    invoice therefore bills only the remaining AED 9,000.00 net plus AED 450.00 VAT,
+    giving AED 9,450.00 payable.
+
+    CRITICAL - THE FINAL INVOICE BILLS THE BALANCE, NOT THE FULL CONTRACT:
+    Because a tax invoice was already issued for the advance, the final invoice must cover
+    only the remaining balance. cbc:PrepaidAmount is deliberately left out: the invoice
+    already reflects only the outstanding amount, so no further advance adjustment applies.
+    Do not bill the full AED 10,000.00 and then deduct the advance via PrepaidAmount.
+
+    Key Fields:
+    - BG-3 BillingReference to the advance invoice: IBT-25 preceding invoice number and
+      IBT-26 preceding invoice issue date (ADV-001, 2026-05-01)
+    - BT-22 Note: the advance reference is also restated in free text, which Appendix 5
+      offers as an alternative to the BillingReference
+    - cbc:PrepaidAmount: intentionally absent
+    - BT-115 PayableAmount AED 9,450.00 = the balance plus its VAT
+
+    Note on retention: Appendix 5 also covers retention. A business may invoice the amount
+    payable after deducting the retained amount, then issue a separate invoice for the
+    retained amount once the buyer becomes liable to release it. Each is a standard Tax
+    Invoice (380) following the same pattern as this example.
+
+    Reference: UAE Electronic Invoicing Guidelines V1.1 (1 June 2026), Appendix 5 -
+               Advance Payments and Retention Clarification;
+               Peppol PINT BIS Billing AE 1.0.4
+-->
 <Invoice xmlns:cac="urn:pagero:CommonAggregateComponents:1.0" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:puf="urn:pagero:ExtensionComponent:1.0" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns="urn:pagero:PageroUniversalFormat:Invoice:1.0">
     <cbc:CustomizationID>urn:pagero.com:puf:billing:2.0</cbc:CustomizationID>
     <cbc:ProfileID>urn:pagero.com:puf:billing:1.0</cbc:ProfileID>
@@ -30,8 +73,8 @@
     </cac:BillingReference>
     <cac:AccountingSupplierParty>
         <cac:Party>
-            <!-- BT-34 Seller electronic address. UAE TRN-as-routing-id uses Peppol scheme 0235 -->
-            <cbc:EndpointID schemeID="0235">100000000000003</cbc:EndpointID>
+            <!-- BT-34 Seller electronic address. The Peppol Participant Identifier is the 10-digit TIN (first 10 digits of the TRN) under scheme 0235 -->
+            <cbc:EndpointID schemeID="0235">1000000000</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-12 Seller legal registration authority (issuer of the trade license) -->
                 <cbc:ID schemeID="AE:LRA">Department of Economic Development - Dubai</cbc:ID>
@@ -66,7 +109,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- BT-49 Buyer electronic address -->
-            <cbc:EndpointID schemeID="0235">100000000001003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000100</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-11 Buyer legal registration authority -->
                 <cbc:ID schemeID="AE:LRA">Abu Dhabi Department of Economic Development</cbc:ID>
@@ -85,7 +128,7 @@
             </cac:PostalAddress>
             <cac:PartyTaxScheme>
                 <!-- BT-48 Buyer VAT identifier -->
-                <cbc:CompanyID>100000000001003</cbc:CompanyID>
+                <cbc:CompanyID>100000010001003</cbc:CompanyID>
                 <cac:TaxScheme>
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_ContinuousSupply.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_ContinuousSupply.xml
@@ -1,4 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+    PUF Invoice Example: Continuous Supply
+
+    Use Case: An instalment invoice issued under a continuing supply arrangement - a supply
+              provided on an ongoing or recurring basis, or one that involves periodic
+              invoicing. The Guidelines cite a monthly advisory retainer as an example.
+
+    Country: United Arab Emirates
+    Format: PUF (Pagero Universal Format) 2.0
+    Document Type: Tax Invoice (Type 380)
+    Transaction Type: BTAE-02 = 00001000 (position 5 = Continuous supply)
+    Target Format: Peppol PINT BIS Billing AE 1.0.4
+
+    Scenario Description:
+    Acme Advisory LLC (Dubai) bills Burj Holdings PJSC (Abu Dhabi) for the April 2026
+    instalment of a 12-month advisory retainer agreed under master service agreement
+    MSA-2025-ACME-BURJ-007. The monthly fee is AED 7,500.00 plus 5% VAT.
+
+    Key Fields:
+    - BTAE-02 position 5 = 1 flags the continuous supply context
+    - BG-14 InvoicePeriod: states the supply window the instalment covers (April 2026)
+    - BT-12 ContractDocumentReference: links the instalment to the master agreement
+    - BTAE-13 Item type: S (Services), which makes the Service Accounting Code
+      BTAE-17 mandatory (ibr-185-ae); the SAC scheme identifier must be SAC (ibr-189-ae)
+    - BTAE-17 SAC 9983.11 = management consulting services
+
+    Note: Where a continuous supply involves retention amounts, the Guidelines require the
+    retention calculation to be issued as a separate commercial document - it must not
+    appear on the Electronic Invoice. A tax invoice for the retained amount is issued
+    separately once that amount falls due.
+
+    Reference: UAE Electronic Invoicing Guidelines V1.1 (1 June 2026), transaction type 5
+               (Continuous supply); Peppol PINT BIS Billing AE 1.0.4
+-->
 <Invoice xmlns:cac="urn:pagero:CommonAggregateComponents:1.0" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:puf="urn:pagero:ExtensionComponent:1.0" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns="urn:pagero:PageroUniversalFormat:Invoice:1.0">
     <cbc:CustomizationID>urn:pagero.com:puf:billing:2.0</cbc:CustomizationID>
     <cbc:ProfileID>urn:pagero.com:puf:billing:1.0</cbc:ProfileID>
@@ -20,7 +54,7 @@
     </cac:ContractDocumentReference>
     <cac:AccountingSupplierParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0235">100000000000003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000000</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-12 Seller legal registration authority (issuer of the trade license) -->
                 <cbc:ID schemeID="AE:LRA">Department of Economic Development - Dubai</cbc:ID>
@@ -47,7 +81,7 @@
     </cac:AccountingSupplierParty>
     <cac:AccountingCustomerParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0235">100000000001003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000100</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-11 Buyer legal registration authority (issuer of the trade license) -->
                 <cbc:ID schemeID="AE:LRA">Abu Dhabi Department of Economic Development</cbc:ID>
@@ -61,7 +95,7 @@
                 </cac:Country>
             </cac:PostalAddress>
             <cac:PartyTaxScheme>
-                <cbc:CompanyID>100000000001003</cbc:CompanyID>
+                <cbc:CompanyID>100000010001003</cbc:CompanyID>
                 <cac:TaxScheme>
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
@@ -75,6 +109,14 @@
     <cac:PaymentMeans>
         <!-- BT-81 Payment means type code: 30 = Credit transfer -->
         <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+            <!-- BT-84 Payment account identifier (IBAN). Mandatory when BT-81 is 30 (ibr-192-ae) -->
+            <cbc:ID>AE070331234567890123456</cbc:ID>
+            <cac:FinancialInstitutionBranch>
+                <!-- BT-86 BIC -->
+                <cbc:ID>EBILAEAD</cbc:ID>
+            </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
     </cac:PaymentMeans>
     <cac:TaxTotal>
         <cbc:TaxAmount currencyID="AED">375.00</cbc:TaxAmount>
@@ -112,16 +154,15 @@
             </cac:AdditionalItemIdentification>
             <cac:CommodityClassification>
                 <cbc:CommodityCode>S</cbc:CommodityCode>
-                <cbc:ItemClassificationCode listID="HS">8523.49.00</cbc:ItemClassificationCode>
             </cac:CommodityClassification>
-        <cac:ClassifiedTaxCategory>
+            <cac:ClassifiedTaxCategory>
                 <cbc:ID>S</cbc:ID>
                 <cbc:Percent>5.00</cbc:Percent>
                 <cac:TaxScheme>
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
             </cac:ClassifiedTaxCategory>
-            </cac:Item>
+        </cac:Item>
         <cac:Price>
             <cbc:PriceAmount currencyID="AED">7500.00</cbc:PriceAmount>
             <cbc:BaseQuantity unitCode="MON">1</cbc:BaseQuantity>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_ContinuousSupply.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_ContinuousSupply.xml
@@ -105,23 +105,15 @@
             <cbc:TaxAmount currencyID="AED">375.00</cbc:TaxAmount>
         </cac:TaxTotal>
         <cac:Item>
-            <ext:UBLExtensions>
-                <ext:UBLExtension>
-                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ItemExtension</ext:ExtensionURI>
-                    <ext:ExtensionContent>
-                        <puf:PageroExtension>
-                            <puf:ItemExtension>
-                                <puf:ItemType>SERVICES</puf:ItemType>
-                            </puf:ItemExtension>
-                        </puf:PageroExtension>
-                    </ext:ExtensionContent>
-                </ext:UBLExtension>
-            </ext:UBLExtensions>
             <cbc:Description>April 2026 instalment of the 12-month advisory retainer (MSA-2025-ACME-BURJ-007)</cbc:Description>
             <cbc:Name>Monthly advisory retainer</cbc:Name>
             <cac:AdditionalItemIdentification>
                 <cbc:ID schemeID="SAC">9983.11</cbc:ID>
             </cac:AdditionalItemIdentification>
+            <cac:CommodityClassification>
+                <cbc:CommodityCode>S</cbc:CommodityCode>
+                <cbc:ItemClassificationCode listID="HS">8523.49.00</cbc:ItemClassificationCode>
+            </cac:CommodityClassification>
         <cac:ClassifiedTaxCategory>
                 <cbc:ID>S</cbc:ID>
                 <cbc:Percent>5.00</cbc:Percent>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_DeemedSupply.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_DeemedSupply.xml
@@ -95,21 +95,10 @@
             <cbc:TaxAmount currencyID="AED">25.00</cbc:TaxAmount>
         </cac:TaxTotal>
         <cac:Item>
-            <ext:UBLExtensions>
-                <ext:UBLExtension>
-                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ItemExtension</ext:ExtensionURI>
-                    <ext:ExtensionContent>
-                        <puf:PageroExtension>
-                            <puf:ItemExtension>
-                                <puf:ItemType>GOODS</puf:ItemType>
-                            </puf:ItemExtension>
-                        </puf:PageroExtension>
-                    </ext:ExtensionContent>
-                </ext:UBLExtension>
-            </ext:UBLExtensions>
-        <cbc:Description>Above-threshold gift to a non-employee — deemed supply per UAE VAT Decree-Law Article 11</cbc:Description>
+            <cbc:Description>Above-threshold gift to a non-employee — deemed supply per UAE VAT Decree-Law Article 11</cbc:Description>
             <cbc:Name>Promotional gift hamper</cbc:Name>
             <cac:CommodityClassification>
+                <cbc:CommodityCode>G</cbc:CommodityCode>
                 <cbc:ItemClassificationCode listID="HS">2106.90.99</cbc:ItemClassificationCode>
             </cac:CommodityClassification>
             <cac:ClassifiedTaxCategory>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_DeemedSupply.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_DeemedSupply.xml
@@ -1,4 +1,42 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+    PUF Invoice Example: Deemed Supply
+
+    Use Case: A supply made by a VAT-registered person that is deemed a taxable supply for
+              VAT purposes - typically supplies for no consideration such as free-of-charge
+              goods, gifts exceeding the prescribed threshold, or the private use of
+              business assets or inventory.
+
+    Country: United Arab Emirates
+    Format: PUF (Pagero Universal Format) 2.0
+    Document Type: Tax Invoice (Type 380)
+    Transaction Type: BTAE-02 = 01000000 (position 2 = Deemed supply)
+    Target Format: Peppol PINT BIS Billing AE 1.0.4
+
+    Scenario Description:
+    Acme Trading LLC (Dubai) distributes 5 promotional gift hampers valued at AED 100.00
+    each. No consideration is received, but VAT of AED 25.00 is accounted for on the
+    deemed supply.
+
+    CRITICAL - FIXED BUYER ENDPOINT:
+    The Guidelines state that for a deemed supply the buyer electronic address must always
+    be 0235:9900000097, and that this value does not change based on the identity of the
+    supplier. Where no invoice is issued to a recipient, there is no exchange of Electronic
+    Invoices at all - only reporting to the FTA by the supplier's ASP.
+
+    Key Fields:
+    - BTAE-02 position 2 = 1 flags the deemed supply context
+    - BT-49 Buyer electronic address: fixed placeholder 9900000097 under scheme 0235
+    - BT-48 Buyer TRN: FTA placeholder, still subject to the 15-digit format (ibr-132-ae)
+    - BT-113 PrepaidAmount equals BT-112 TaxInclusiveAmount, so BT-115 PayableAmount is 0.00
+    - BT-9 Payment due date is deliberately absent: deemed supplies are exempt from the
+      due date requirement (ibr-127-ae)
+    - BT-81 Payment means is likewise not required for deemed supplies (ibr-191-ae)
+
+    Reference: UAE Electronic Invoicing Guidelines V1.1 (1 June 2026), transaction type 2
+               (Deemed supply); Articles 11 and 12 of the VAT Decree-Law;
+               Peppol PINT BIS Billing AE 1.0.4
+-->
 <Invoice xmlns:cac="urn:pagero:CommonAggregateComponents:1.0" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:puf="urn:pagero:ExtensionComponent:1.0" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns="urn:pagero:PageroUniversalFormat:Invoice:1.0">
     <cbc:CustomizationID>urn:pagero.com:puf:billing:2.0</cbc:CustomizationID>
     <cbc:ProfileID>urn:pagero.com:puf:billing:1.0</cbc:ProfileID>
@@ -9,7 +47,7 @@
     <cbc:DocumentCurrencyCode>AED</cbc:DocumentCurrencyCode>
     <cac:AccountingSupplierParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0235">100000000000003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000000</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-12 Seller legal registration authority (issuer of the trade license) -->
                 <cbc:ID schemeID="AE:LRA">Department of Economic Development - Dubai</cbc:ID>
@@ -59,10 +97,10 @@
             </cac:PartyLegalEntity>
         </cac:Party>
     </cac:AccountingCustomerParty>
-    <cac:PaymentMeans>
-        <!-- BT-81 Payment means type code: 30 = Credit transfer -->
-        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
-    </cac:PaymentMeans>
+    <!-- BT-81 Payment means is deliberately omitted. A deemed supply carries no consideration
+         (PayableAmount 0.00), and ibr-191-ae exempts deemed supplies from requiring a payment
+         means type code. Declaring credit transfer here would also pull in a mandatory payee
+         account (ibr-192-ae) for an invoice that is never paid. -->
     <cac:TaxTotal>
         <cbc:TaxAmount currencyID="AED">25.00</cbc:TaxAmount>
         <cac:TaxSubtotal>
@@ -108,7 +146,7 @@
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
             </cac:ClassifiedTaxCategory>
-            </cac:Item>
+        </cac:Item>
         <cac:Price>
             <cbc:PriceAmount currencyID="AED">100.00</cbc:PriceAmount>
             <cbc:BaseQuantity unitCode="EA">1</cbc:BaseQuantity>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_DisclosedAgent.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_DisclosedAgent.xml
@@ -13,6 +13,10 @@
                                      MUST differ from the Seller's VAT identifier (ibr-176-ae). -->
                                 <cbc:ID>100000000000555</cbc:ID>
                             </cac:PartyIdentification>
+                            <cac:PartyLegalEntity>
+                                <cbc:RegistrationName>National Insurance Co. PJSC</cbc:RegistrationName>
+                                <cbc:CompanyID>100000000000555</cbc:CompanyID>
+                            </cac:PartyLegalEntity>
                         </cac:Party>
                     </puf:RestrictedInformationParty>
                 </puf:PageroExtension>
@@ -116,23 +120,15 @@
             <cbc:TaxAmount currencyID="AED">125.00</cbc:TaxAmount>
         </cac:TaxTotal>
         <cac:Item>
-            <ext:UBLExtensions>
-                <ext:UBLExtension>
-                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ItemExtension</ext:ExtensionURI>
-                    <ext:ExtensionContent>
-                        <puf:PageroExtension>
-                            <puf:ItemExtension>
-                                <puf:ItemType>SERVICES</puf:ItemType>
-                            </puf:ItemExtension>
-                        </puf:PageroExtension>
-                    </ext:ExtensionContent>
-                </ext:UBLExtension>
-            </ext:UBLExtensions>
             <cbc:Description>Premium collected on behalf of the principal (National Insurance Co. PJSC) — disclosed agent billing</cbc:Description>
             <cbc:Name>Annual general liability insurance premium</cbc:Name>
             <cac:AdditionalItemIdentification>
                 <cbc:ID schemeID="SAC">9971.31</cbc:ID>
             </cac:AdditionalItemIdentification>
+            <cac:CommodityClassification>
+                <cbc:CommodityCode>S</cbc:CommodityCode>
+                <cbc:ItemClassificationCode listID="HS">4907.00.90</cbc:ItemClassificationCode>
+            </cac:CommodityClassification>
         <cac:ClassifiedTaxCategory>
                 <cbc:ID>S</cbc:ID>
                 <cbc:Percent>5.00</cbc:Percent>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_DisclosedAgent.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_DisclosedAgent.xml
@@ -1,4 +1,42 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+    PUF Invoice Example: Disclosed Agent Billing
+
+    Use Case: A person acting as a disclosed agent on behalf of a principal, issuing
+              invoices on the principal's behalf. The Guidelines cite an insurance broker
+              collecting premiums from a buyer on behalf of a VAT-registered insurance
+              company as the worked example. This scenario does NOT apply to undisclosed
+              agents.
+
+    Country: United Arab Emirates
+    Format: PUF (Pagero Universal Format) 2.0
+    Document Type: Tax Invoice (Type 380)
+    Transaction Type: BTAE-02 = 00000100 (position 6 = Disclosed agent)
+    Target Format: Peppol PINT BIS Billing AE 1.0.4
+
+    Scenario Description:
+    Premier Insurance Brokers LLC (Dubai) invoices Burj Holdings PJSC (Abu Dhabi) for an
+    annual general liability insurance premium of AED 2,500.00 plus 5% VAT, collected on
+    behalf of the principal National Insurance Co. PJSC.
+
+    Key Fields:
+    - BTAE-02 position 6 = 1 flags the disclosed agent context
+    - BTAE-14 Principle ID: mandatory whenever the disclosed agent flag is set (ibr-137-ae).
+      Carried in PUF as puf:RestrictedInformationParty with puf:Key = 'Principle'
+    - The Principle TRN MUST differ from the Seller VAT identifier BT-31 (ibr-176-ae)
+    - Either the seller TRN or the seller TIN must also be present in this scenario
+      (ibr-177-ae)
+    - BTAE-13 Item type S with SAC 9971.31 (insurance services)
+
+    Note: The Guidelines stress that responsibility for issuing the Electronic Invoice
+    remains with the supplier even when an agent issues one on its behalf.
+
+    Note on the target mapping: in the PINT AE output the Principle is emitted as
+    cac:SellerSupplierParty.
+
+    Reference: UAE Electronic Invoicing Guidelines V1.1 (1 June 2026), transaction type 6
+               (Agent billing); Peppol PINT BIS Billing AE 1.0.4
+-->
 <Invoice xmlns:cac="urn:pagero:CommonAggregateComponents:1.0" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:puf="urn:pagero:ExtensionComponent:1.0" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns="urn:pagero:PageroUniversalFormat:Invoice:1.0">
     <ext:UBLExtensions>
         <ext:UBLExtension>
@@ -34,7 +72,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- The agent (broker) issuing the invoice on the principal's behalf -->
-            <cbc:EndpointID schemeID="0235">100000000000003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000000</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-12 Seller legal registration authority (issuer of the trade license) -->
                 <cbc:ID schemeID="AE:LRA">Department of Economic Development - Dubai</cbc:ID>
@@ -62,7 +100,7 @@
     </cac:AccountingSupplierParty>
     <cac:AccountingCustomerParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0235">100000000001003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000100</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-11 Buyer legal registration authority (issuer of the trade license) -->
                 <cbc:ID schemeID="AE:LRA">Abu Dhabi Department of Economic Development</cbc:ID>
@@ -76,7 +114,7 @@
                 </cac:Country>
             </cac:PostalAddress>
             <cac:PartyTaxScheme>
-                <cbc:CompanyID>100000000001003</cbc:CompanyID>
+                <cbc:CompanyID>100000010001003</cbc:CompanyID>
                 <cac:TaxScheme>
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
@@ -90,6 +128,14 @@
     <cac:PaymentMeans>
         <!-- BT-81 Payment means type code: 30 = Credit transfer -->
         <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+            <!-- BT-84 Payment account identifier (IBAN). Mandatory when BT-81 is 30 (ibr-192-ae) -->
+            <cbc:ID>AE070331234567890123456</cbc:ID>
+            <cac:FinancialInstitutionBranch>
+                <!-- BT-86 BIC -->
+                <cbc:ID>EBILAEAD</cbc:ID>
+            </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
     </cac:PaymentMeans>
     <cac:TaxTotal>
         <cbc:TaxAmount currencyID="AED">125.00</cbc:TaxAmount>
@@ -127,16 +173,15 @@
             </cac:AdditionalItemIdentification>
             <cac:CommodityClassification>
                 <cbc:CommodityCode>S</cbc:CommodityCode>
-                <cbc:ItemClassificationCode listID="HS">4907.00.90</cbc:ItemClassificationCode>
             </cac:CommodityClassification>
-        <cac:ClassifiedTaxCategory>
+            <cac:ClassifiedTaxCategory>
                 <cbc:ID>S</cbc:ID>
                 <cbc:Percent>5.00</cbc:Percent>
                 <cac:TaxScheme>
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
             </cac:ClassifiedTaxCategory>
-            </cac:Item>
+        </cac:Item>
         <cac:Price>
             <cbc:PriceAmount currencyID="AED">2500.00</cbc:PriceAmount>
             <cbc:BaseQuantity unitCode="EA">1</cbc:BaseQuantity>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_ECommerce.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_ECommerce.xml
@@ -117,21 +117,10 @@
             <cbc:TaxAmount currencyID="AED">21.00</cbc:TaxAmount>
         </cac:TaxTotal>
         <cac:Item>
-            <ext:UBLExtensions>
-                <ext:UBLExtension>
-                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ItemExtension</ext:ExtensionURI>
-                    <ext:ExtensionContent>
-                        <puf:PageroExtension>
-                            <puf:ItemExtension>
-                                <puf:ItemType>GOODS</puf:ItemType>
-                            </puf:ItemExtension>
-                        </puf:PageroExtension>
-                    </ext:ExtensionContent>
-                </ext:UBLExtension>
-            </ext:UBLExtensions>
-        <cbc:Description>Online order placed via merchant website (WEB-ORD-2026-04-9837)</cbc:Description>
+            <cbc:Description>Online order placed via merchant website (WEB-ORD-2026-04-9837)</cbc:Description>
             <cbc:Name>Wireless headphones, model X-200</cbc:Name>
             <cac:CommodityClassification>
+                <cbc:CommodityCode>G</cbc:CommodityCode>
                 <cbc:ItemClassificationCode listID="HS">8518.30.20</cbc:ItemClassificationCode>
             </cac:CommodityClassification>
             <cac:ClassifiedTaxCategory>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_ECommerce.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_ECommerce.xml
@@ -1,4 +1,35 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+    PUF Invoice Example: Supply Through E-Commerce
+
+    Use Case: A supply made through an Electronic Commerce Medium as defined by Ministerial
+              Decision No. 26 of 2023. The Guidelines note that responsibility for issuing
+              the Electronic Invoice stays with the supplier even when the e-commerce
+              platform issues it on the supplier's behalf.
+
+    Country: United Arab Emirates
+    Format: PUF (Pagero Universal Format) 2.0
+    Document Type: Tax Invoice (Type 380)
+    Transaction Type: BTAE-02 = 00000010 (position 7 = E-commerce)
+    Target Format: Peppol PINT BIS Billing AE 1.0.4
+
+    Scenario Description:
+    Online Retail UAE LLC sells 3 pairs of wireless headphones at AED 140.00 each through
+    its website, shipped to a Burj Holdings PJSC address in Dubai Marina. Total AED 420.00
+    net plus AED 21.00 VAT.
+
+    Key Fields:
+    - BTAE-02 position 7 = 1 flags the e-commerce context
+    - BG-13 Delivery: for e-commerce supplies the deliver-to address line 1 (BT-75),
+      city (BT-77) and country subdivision (BT-79) are all mandatory (ibr-142-ae).
+      This is the main structural difference from the standard invoice
+    - BT-13 OrderReference: the web platform order number
+    - BT-79 Deliver-to emirate must be a valid UAE emirate code when the delivery
+      country is AE (ibr-128-ae)
+
+    Reference: UAE Electronic Invoicing Guidelines V1.1 (1 June 2026), transaction type 7
+               (Supply through e-Commerce); Peppol PINT BIS Billing AE 1.0.4
+-->
 <Invoice xmlns:cac="urn:pagero:CommonAggregateComponents:1.0" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:puf="urn:pagero:ExtensionComponent:1.0" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns="urn:pagero:PageroUniversalFormat:Invoice:1.0">
     <cbc:CustomizationID>urn:pagero.com:puf:billing:2.0</cbc:CustomizationID>
     <cbc:ProfileID>urn:pagero.com:puf:billing:1.0</cbc:ProfileID>
@@ -13,7 +44,7 @@
     </cac:OrderReference>
     <cac:AccountingSupplierParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0235">100000000000003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000000</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-12 Seller legal registration authority (issuer of the trade license) -->
                 <cbc:ID schemeID="AE:LRA">Department of Economic Development - Dubai</cbc:ID>
@@ -40,7 +71,7 @@
     </cac:AccountingSupplierParty>
     <cac:AccountingCustomerParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0235">100000000001003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000100</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-11 Buyer legal registration authority (issuer of the trade license) -->
                 <cbc:ID schemeID="AE:LRA">Department of Economic Development - Dubai</cbc:ID>
@@ -54,7 +85,7 @@
                 </cac:Country>
             </cac:PostalAddress>
             <cac:PartyTaxScheme>
-                <cbc:CompanyID>100000000001003</cbc:CompanyID>
+                <cbc:CompanyID>100000010001003</cbc:CompanyID>
                 <cac:TaxScheme>
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
@@ -87,6 +118,14 @@
     <cac:PaymentMeans>
         <!-- BT-81 Payment means type code: 30 = Credit transfer -->
         <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+            <!-- BT-84 Payment account identifier (IBAN). Mandatory when BT-81 is 30 (ibr-192-ae) -->
+            <cbc:ID>AE070331234567890123456</cbc:ID>
+            <cac:FinancialInstitutionBranch>
+                <!-- BT-86 BIC -->
+                <cbc:ID>EBILAEAD</cbc:ID>
+            </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
     </cac:PaymentMeans>
     <cac:TaxTotal>
         <cbc:TaxAmount currencyID="AED">21.00</cbc:TaxAmount>
@@ -130,7 +169,7 @@
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
             </cac:ClassifiedTaxCategory>
-            </cac:Item>
+        </cac:Item>
         <cac:Price>
             <cbc:PriceAmount currencyID="AED">140.00</cbc:PriceAmount>
             <cbc:BaseQuantity unitCode="EA">1</cbc:BaseQuantity>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_Exports.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_Exports.xml
@@ -1,4 +1,43 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+    PUF Invoice Example: Export Supply
+
+    Use Case: Goods or services supplied to a customer outside the UAE. The Guidelines cite
+              a UAE wholesaler exporting cosmetics to a retailer in Kuwait as the worked
+              example. Exports are zero rated.
+
+    Country: United Arab Emirates
+    Format: PUF (Pagero Universal Format) 2.0
+    Document Type: Tax Invoice (Type 380)
+    Transaction Type: BTAE-02 = 00000001 (position 8 = Exports)
+    Target Format: Peppol PINT BIS Billing AE 1.0.4
+
+    Scenario Description:
+    Acme Cosmetics LLC (Dubai) exports 500 premium skincare sets at AED 30.00 each to
+    Gulf Beauty Retail W.L.L. in Salmiya, Kuwait. The supply is zero rated, so net and
+    gross are both AED 15,000.00.
+
+    CRITICAL - PLACEHOLDER ENDPOINT FOR NON-PEPPOL BUYERS:
+    The Guidelines state that for exports, if the buyer does not have a Peppol ID, the
+    predefined endpoint 0235:9900000099 must be included by the supplier on the Electronic
+    Invoice. A foreign buyer that does have a Peppol ID uses its own address instead.
+
+    Key Fields:
+    - BTAE-02 position 8 = 1 flags the export context
+    - BT-49 Buyer electronic address: predefined placeholder 9900000099 under scheme 0235
+    - BT-151 / BT-118 VAT category: Z (Zero rated) with rate 0.00
+    - BG-13 Delivery: deliver-to address line 1 (BT-75), city (BT-77) and country
+      subdivision (BT-79) are mandatory for exports where the delivery country is not AE
+      (ibr-152-ae)
+    - BTAE-22 Incoterms: carried on cac:DeliveryTerms/cbc:ID, maximum 3 characters.
+      When a DeliveryTerms block is present the Incoterms code is mandatory (ibr-196-ae)
+
+    Note: The Guidelines add that the Tax Invoice issued for an export should be the
+    Electronic Invoice, and the same document may be provided to Customs.
+
+    Reference: UAE Electronic Invoicing Guidelines V1.1 (1 June 2026), transaction type 8
+               (Exports); Peppol PINT BIS Billing AE 1.0.4
+-->
 <Invoice xmlns:cac="urn:pagero:CommonAggregateComponents:1.0" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:puf="urn:pagero:ExtensionComponent:1.0" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns="urn:pagero:PageroUniversalFormat:Invoice:1.0">
     <cbc:CustomizationID>urn:pagero.com:puf:billing:2.0</cbc:CustomizationID>
     <cbc:ProfileID>urn:pagero.com:puf:billing:1.0</cbc:ProfileID>
@@ -10,7 +49,7 @@
     <cbc:DocumentCurrencyCode>AED</cbc:DocumentCurrencyCode>
     <cac:AccountingSupplierParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0235">100000000000003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000000</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-12 Seller legal registration authority (issuer of the trade license) -->
                 <cbc:ID schemeID="AE:LRA">Department of Economic Development - Dubai</cbc:ID>
@@ -80,6 +119,14 @@
     <cac:PaymentMeans>
         <!-- BT-81 Payment means type code: 30 = Credit transfer -->
         <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+            <!-- BT-84 Payment account identifier (IBAN). Mandatory when BT-81 is 30 (ibr-192-ae) -->
+            <cbc:ID>AE070331234567890123456</cbc:ID>
+            <cac:FinancialInstitutionBranch>
+                <!-- BT-86 BIC -->
+                <cbc:ID>EBILAEAD</cbc:ID>
+            </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
     </cac:PaymentMeans>
     <cac:TaxTotal>
         <cbc:TaxAmount currencyID="AED">0.00</cbc:TaxAmount>
@@ -124,7 +171,7 @@
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
             </cac:ClassifiedTaxCategory>
-            </cac:Item>
+        </cac:Item>
         <cac:Price>
             <cbc:PriceAmount currencyID="AED">30.00</cbc:PriceAmount>
             <cbc:BaseQuantity unitCode="EA">1</cbc:BaseQuantity>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_Exports.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_Exports.xml
@@ -111,21 +111,10 @@
             <cbc:TaxAmount currencyID="AED">0.00</cbc:TaxAmount>
         </cac:TaxTotal>
         <cac:Item>
-            <ext:UBLExtensions>
-                <ext:UBLExtension>
-                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ItemExtension</ext:ExtensionURI>
-                    <ext:ExtensionContent>
-                        <puf:PageroExtension>
-                            <puf:ItemExtension>
-                                <puf:ItemType>GOODS</puf:ItemType>
-                            </puf:ItemExtension>
-                        </puf:PageroExtension>
-                    </ext:ExtensionContent>
-                </ext:UBLExtension>
-            </ext:UBLExtensions>
-        <cbc:Description>Wholesale export shipment to Kuwait retailer</cbc:Description>
+            <cbc:Description>Wholesale export shipment to Kuwait retailer</cbc:Description>
             <cbc:Name>Premium skincare set, 50ml</cbc:Name>
             <cac:CommodityClassification>
+                <cbc:CommodityCode>G</cbc:CommodityCode>
                 <cbc:ItemClassificationCode listID="HS">3304.99.00</cbc:ItemClassificationCode>
             </cac:CommodityClassification>
             <cac:ClassifiedTaxCategory>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_Foreign_Currency.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_Foreign_Currency.xml
@@ -1,4 +1,44 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+    PUF Invoice Example: Foreign Currency Invoice (USD)
+
+    Use Case: An invoice denominated in a currency other than AED. UAE requires the VAT to
+              be reported in AED regardless of the invoice currency, so the document carries
+              a second set of tax amounts in the tax accounting currency alongside the
+              trading amounts.
+
+    Country: United Arab Emirates
+    Format: PUF (Pagero Universal Format) 2.0
+    Document Type: Tax Invoice (Type 380)
+    Transaction Type: BTAE-02 = 00000000 (no special transaction context)
+    Target Format: Peppol PINT BIS Billing AE 1.0.4
+
+    Scenario Description:
+    Acme Trading LLC (Dubai) invoices Burj Holdings PJSC (Abu Dhabi) for 10 industrial
+    pumps at USD 100.00 each. Net USD 1,000.00 plus USD 50.00 VAT. All VAT figures are
+    additionally reported in AED at 1 USD = 3.6725 AED.
+
+    CRITICAL - THIS IS THE MOST EXTENSION-HEAVY UAE EXAMPLE:
+    UAE has no single UBL element for most AED-equivalent amounts, so PUF carries them
+    through extensions. Use this example as the reference whenever a UAE customer trades
+    in a currency other than AED.
+
+    Key Fields:
+    - BT-5 DocumentCurrencyCode USD; BT-6 TaxCurrencyCode AED. When present, the tax
+      accounting currency must be AED (ibr-140-ae)
+    - BTAE-04 TaxExchangeRate: mandatory when the invoice currency is not AED (ibr-159-ae).
+      Maximum 6 decimal places (ibr-002-ae). Source currency must be BT-5 and target
+      currency must be BT-6 (ibr-153-ae)
+    - BT-110 / BT-111: two document-level TaxTotal blocks, first in USD then in AED.
+      Both the AED tax total and BTAE-20 must be present (ibr-175-ae)
+    - IBT-190 per-category AED tax: puf:TaxSubtotalExtension/puf:TaxCurrencyTaxAmount
+    - BTAE-20 total with VAT in AED: puf:LegalMonetaryTotalExtension/
+      puf:TaxCurrencyTaxInclusiveAmount
+    - BTAE-08 / BTAE-10 line VAT and line amount in AED (ibr-104-ae, ibr-194-ae)
+
+    Reference: UAE Electronic Invoicing Guidelines V1.1 (1 June 2026);
+               Peppol PINT BIS Billing AE 1.0.4
+-->
 <Invoice xmlns:cac="urn:pagero:CommonAggregateComponents:1.0" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:puf="urn:pagero:ExtensionComponent:1.0" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns="urn:pagero:PageroUniversalFormat:Invoice:1.0">
     <cbc:CustomizationID>urn:pagero.com:puf:billing:2.0</cbc:CustomizationID>
     <cbc:ProfileID>urn:pagero.com:puf:billing:1.0</cbc:ProfileID>
@@ -12,7 +52,7 @@
     <cbc:TaxCurrencyCode>AED</cbc:TaxCurrencyCode>
     <cac:AccountingSupplierParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0235">100000000000003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000000</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-12 Seller legal registration authority (issuer of the trade license) -->
                 <cbc:ID schemeID="AE:LRA">Department of Economic Development - Dubai</cbc:ID>
@@ -39,7 +79,7 @@
     </cac:AccountingSupplierParty>
     <cac:AccountingCustomerParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0235">100000000001003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000100</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-11 Buyer legal registration authority (issuer of the trade license) -->
                 <cbc:ID schemeID="AE:LRA">Abu Dhabi Department of Economic Development</cbc:ID>
@@ -53,7 +93,7 @@
                 </cac:Country>
             </cac:PostalAddress>
             <cac:PartyTaxScheme>
-                <cbc:CompanyID>100000000001003</cbc:CompanyID>
+                <cbc:CompanyID>100000010001003</cbc:CompanyID>
                 <cac:TaxScheme>
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
@@ -67,6 +107,14 @@
     <cac:PaymentMeans>
         <!-- BT-81 Payment means type code: 30 = Credit transfer -->
         <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+            <!-- BT-84 Payment account identifier (IBAN). Mandatory when BT-81 is 30 (ibr-192-ae) -->
+            <cbc:ID>AE070331234567890123456</cbc:ID>
+            <cac:FinancialInstitutionBranch>
+                <!-- BT-86 BIC -->
+                <cbc:ID>EBILAEAD</cbc:ID>
+            </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
     </cac:PaymentMeans>
     <!-- BTAE-04 Currency exchange rate. Source must be document currency, target must be tax currency
          (ibr-153-ae). Rate must contain at most 6 decimals (ibr-002-ae). -->
@@ -140,7 +188,7 @@
                 </ext:ExtensionContent>
             </ext:UBLExtension>
         </ext:UBLExtensions>
-    <cbc:ID>1</cbc:ID>
+        <cbc:ID>1</cbc:ID>
         <cbc:InvoicedQuantity unitCode="EA">10</cbc:InvoicedQuantity>
         <cbc:LineExtensionAmount currencyID="USD">1000.00</cbc:LineExtensionAmount>
         <!-- BTAE-08 VAT line amount in AED. Required when DocumentCurrencyCode != 'AED' (ibr-104-ae)
@@ -165,7 +213,7 @@
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
             </cac:ClassifiedTaxCategory>
-            </cac:Item>
+        </cac:Item>
         <cac:Price>
             <cbc:PriceAmount currencyID="USD">100.00</cbc:PriceAmount>
             <cbc:BaseQuantity unitCode="EA">1</cbc:BaseQuantity>
@@ -177,5 +225,5 @@
             </cac:AllowanceCharge>
         </cac:Price>
         <!-- BTAE-10 Invoice line amount with VAT in AED. Required when DocumentCurrencyCode != 'AED' (ibr-194-ae). -->
-        </cac:InvoiceLine>
+    </cac:InvoiceLine>
 </Invoice>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_Foreign_Currency.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_Foreign_Currency.xml
@@ -152,21 +152,10 @@
             <cbc:TaxAmount currencyID="AED">183.63</cbc:TaxAmount>
         </cac:TaxTotal>
         <cac:Item>
-            <ext:UBLExtensions>
-                <ext:UBLExtension>
-                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ItemExtension</ext:ExtensionURI>
-                    <ext:ExtensionContent>
-                        <puf:PageroExtension>
-                            <puf:ItemExtension>
-                                <puf:ItemType>GOODS</puf:ItemType>
-                            </puf:ItemExtension>
-                        </puf:PageroExtension>
-                    </ext:ExtensionContent>
-                </ext:UBLExtension>
-            </ext:UBLExtensions>
-        <cbc:Description>Industrial-grade centrifugal water pump, 5HP</cbc:Description>
+            <cbc:Description>Industrial-grade centrifugal water pump, 5HP</cbc:Description>
             <cbc:Name>Industrial pump</cbc:Name>
             <cac:CommodityClassification>
+                <cbc:CommodityCode>G</cbc:CommodityCode>
                 <cbc:ItemClassificationCode listID="HS">8413.70.10</cbc:ItemClassificationCode>
             </cac:CommodityClassification>
             <cac:ClassifiedTaxCategory>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_FreeTradeZone.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_FreeTradeZone.xml
@@ -1,4 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+    PUF Invoice Example: Free Trade Zone Supply
+
+    Use Case: A supply involving a Free Zone, where the contracting customer and the party
+              that ultimately benefits from the supply are not the same legal entity. The
+              Guidelines direct that the customer is the person who issued the purchase
+              order or is the contracting party, and that where the ultimate beneficiary
+              differs from that buyer, the beneficiary must also be recorded on the invoice.
+
+    Country: United Arab Emirates
+    Format: PUF (Pagero Universal Format) 2.0
+    Document Type: Tax Invoice (Type 380)
+    Transaction Type: BTAE-02 = 10000000 (position 1 = Free trade zone)
+    Target Format: Peppol PINT BIS Billing AE 1.0.4
+
+    Scenario Description:
+    JAFZA Logistics FZE (Dubai) invoices Burj Holdings PJSC (Abu Dhabi) as the contracting
+    party for 10 industrial pumps at AED 100.00 each, while JAFZA End-User FZE inside the
+    free zone is the declared end user. Net AED 1,000.00 plus AED 50.00 VAT.
+
+    Key Fields:
+    - BTAE-02 position 1 = 1 flags the free trade zone context
+    - BTAE-01 Beneficiary ID: mandatory whenever the FTZ flag is set (ibr-007-ae).
+      Carried in PUF as puf:RestrictedInformationParty with puf:Key = 'Beneficiary'.
+      The value is the beneficiary's TRN or TIN, distinct from the accounting buyer
+    - The beneficiary is separate from cac:AccountingCustomerParty, which remains the
+      contracting party that receives and pays the invoice
+
+    Note on the target mapping: in the PINT AE output the Beneficiary is emitted as
+    cac:BuyerCustomerParty. PUF carries it in a RestrictedInformationParty rather than
+    a dedicated party slot so the same construct can serve several jurisdictions.
+
+    Reference: UAE Electronic Invoicing Guidelines V1.1 (1 June 2026), transaction type 1
+               (Free trade zone); Peppol PINT BIS Billing AE 1.0.4
+-->
 <Invoice xmlns:cac="urn:pagero:CommonAggregateComponents:1.0" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:puf="urn:pagero:ExtensionComponent:1.0" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns="urn:pagero:PageroUniversalFormat:Invoice:1.0">
     <ext:UBLExtensions>
         <ext:UBLExtension>
@@ -32,7 +67,7 @@
     <cbc:DocumentCurrencyCode>AED</cbc:DocumentCurrencyCode>
     <cac:AccountingSupplierParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0235">100000000000003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000000</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-12 Seller legal registration authority (issuer of the trade license) -->
                 <cbc:ID schemeID="AE:LRA">Jebel Ali Free Zone Authority</cbc:ID>
@@ -60,7 +95,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- Customer (contracting party) — distinct from the Beneficiary above -->
-            <cbc:EndpointID schemeID="0235">100000000001003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000100</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-11 Buyer legal registration authority (issuer of the trade license) -->
                 <cbc:ID schemeID="AE:LRA">Abu Dhabi Department of Economic Development</cbc:ID>
@@ -74,7 +109,7 @@
                 </cac:Country>
             </cac:PostalAddress>
             <cac:PartyTaxScheme>
-                <cbc:CompanyID>100000000001003</cbc:CompanyID>
+                <cbc:CompanyID>100000010001003</cbc:CompanyID>
                 <cac:TaxScheme>
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
@@ -88,6 +123,14 @@
     <cac:PaymentMeans>
         <!-- BT-81 Payment means type code: 30 = Credit transfer -->
         <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+            <!-- BT-84 Payment account identifier (IBAN). Mandatory when BT-81 is 30 (ibr-192-ae) -->
+            <cbc:ID>AE070331234567890123456</cbc:ID>
+            <cac:FinancialInstitutionBranch>
+                <!-- BT-86 BIC -->
+                <cbc:ID>EBILAEAD</cbc:ID>
+            </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
     </cac:PaymentMeans>
     <cac:TaxTotal>
         <cbc:TaxAmount currencyID="AED">50.00</cbc:TaxAmount>
@@ -131,7 +174,7 @@
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
             </cac:ClassifiedTaxCategory>
-            </cac:Item>
+        </cac:Item>
         <cac:Price>
             <cbc:PriceAmount currencyID="AED">100.00</cbc:PriceAmount>
             <cbc:BaseQuantity unitCode="EA">1</cbc:BaseQuantity>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_FreeTradeZone.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_FreeTradeZone.xml
@@ -12,6 +12,10 @@
                                 <!-- BTAE-01 Beneficiary ID: TRN of the ultimate beneficiary in the Free Zone -->
                                 <cbc:ID>100000000000777</cbc:ID>
                             </cac:PartyIdentification>
+                            <cac:PartyLegalEntity>
+                                <cbc:RegistrationName>JAFZA End-User FZE</cbc:RegistrationName>
+                                <cbc:CompanyID>100000000000777</cbc:CompanyID>
+                            </cac:PartyLegalEntity>
                         </cac:Party>
                     </puf:RestrictedInformationParty>
                 </puf:PageroExtension>
@@ -114,21 +118,10 @@
             <cbc:TaxAmount currencyID="AED">50.00</cbc:TaxAmount>
         </cac:TaxTotal>
         <cac:Item>
-            <ext:UBLExtensions>
-                <ext:UBLExtension>
-                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ItemExtension</ext:ExtensionURI>
-                    <ext:ExtensionContent>
-                        <puf:PageroExtension>
-                            <puf:ItemExtension>
-                                <puf:ItemType>GOODS</puf:ItemType>
-                            </puf:ItemExtension>
-                        </puf:PageroExtension>
-                    </ext:ExtensionContent>
-                </ext:UBLExtension>
-            </ext:UBLExtensions>
-        <cbc:Description>Centrifugal water pump for FTZ end-user</cbc:Description>
+            <cbc:Description>Centrifugal water pump for FTZ end-user</cbc:Description>
             <cbc:Name>Industrial pump</cbc:Name>
             <cac:CommodityClassification>
+                <cbc:CommodityCode>G</cbc:CommodityCode>
                 <cbc:ItemClassificationCode listID="HS">8413.70.10</cbc:ItemClassificationCode>
             </cac:CommodityClassification>
             <cac:ClassifiedTaxCategory>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_MarginScheme.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_MarginScheme.xml
@@ -1,4 +1,41 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+    PUF Invoice Example: Profit Margin Scheme
+
+    Use Case: A sale where VAT is calculated only on the supplier's margin - the difference
+              between the purchase price and the resale price - rather than on the full
+              sale price. The Guidelines cite a car dealer selling a used car as the
+              worked example.
+
+    Country: United Arab Emirates
+    Format: PUF (Pagero Universal Format) 2.0
+    Document Type: Tax Invoice (Type 380)
+    Transaction Type: BTAE-02 = 00100000 (position 3 = Profit margin scheme)
+    Target Format: Peppol PINT BIS Billing AE 1.0.4
+
+    Scenario Description:
+    Premier Pre-Owned Cars LLC (Dubai) sells a 2022 Toyota Camry to Burj Holdings PJSC
+    for AED 45,000.00 under the profit margin scheme. VAT is assessed on the dealer's
+    margin and settled directly with the FTA, so no VAT is charged on this invoice.
+
+    CRITICAL - VAT AMOUNT IS ZERO, BUT THE RATE IS NOT:
+    The Guidelines state that although PINT AE mandates the inclusion of VAT information,
+    the VAT amount is not required to be displayed for margin scheme transactions and the
+    amount displayed should be 0. The statutory 5.00 rate is still carried in BT-152.
+
+    Key Fields:
+    - BTAE-02 position 3 = 1 flags the margin scheme context
+    - BT-151 / BT-118 VAT category: N (Standard rate additional VAT) on every line - when
+      the margin scheme flag is set, all lines must use category N (ibr-116-ae)
+    - BT-152 rate 5.00 must be greater than zero for category N (ibr-111-ae), while the
+      VAT amount is 0.00
+    - Exactly one VAT breakdown with category N is required (ibr-105-ae)
+    - The vehicle VIN is carried in the item description for traceability
+
+    Reference: UAE Electronic Invoicing Guidelines V1.1 (1 June 2026), transaction type 3
+               (Margin scheme); Article 43 of the VAT Decree-Law on Charging Tax based on
+               Profit Margin; Peppol PINT BIS Billing AE 1.0.4
+-->
 <Invoice xmlns:cac="urn:pagero:CommonAggregateComponents:1.0" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:puf="urn:pagero:ExtensionComponent:1.0" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns="urn:pagero:PageroUniversalFormat:Invoice:1.0">
     <cbc:CustomizationID>urn:pagero.com:puf:billing:2.0</cbc:CustomizationID>
     <cbc:ProfileID>urn:pagero.com:puf:billing:1.0</cbc:ProfileID>
@@ -11,7 +48,7 @@
     <cbc:DocumentCurrencyCode>AED</cbc:DocumentCurrencyCode>
     <cac:AccountingSupplierParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0235">100000000000003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000000</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-12 Seller legal registration authority (issuer of the trade license) -->
                 <cbc:ID schemeID="AE:LRA">Department of Economic Development - Dubai</cbc:ID>
@@ -38,7 +75,7 @@
     </cac:AccountingSupplierParty>
     <cac:AccountingCustomerParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0235">100000000001003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000100</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-11 Buyer legal registration authority (issuer of the trade license) -->
                 <cbc:ID schemeID="AE:LRA">Abu Dhabi Department of Economic Development</cbc:ID>
@@ -52,7 +89,7 @@
                 </cac:Country>
             </cac:PostalAddress>
             <cac:PartyTaxScheme>
-                <cbc:CompanyID>100000000001003</cbc:CompanyID>
+                <cbc:CompanyID>100000010001003</cbc:CompanyID>
                 <cac:TaxScheme>
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
@@ -66,6 +103,14 @@
     <cac:PaymentMeans>
         <!-- BT-81 Payment means type code: 30 = Credit transfer -->
         <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+            <!-- BT-84 Payment account identifier (IBAN). Mandatory when BT-81 is 30 (ibr-192-ae) -->
+            <cbc:ID>AE070331234567890123456</cbc:ID>
+            <cac:FinancialInstitutionBranch>
+                <!-- BT-86 BIC -->
+                <cbc:ID>EBILAEAD</cbc:ID>
+            </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
     </cac:PaymentMeans>
     <cac:TaxTotal>
         <!-- VAT amount forced to 0 for margin-scheme transactions -->
@@ -113,7 +158,7 @@
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
             </cac:ClassifiedTaxCategory>
-            </cac:Item>
+        </cac:Item>
         <cac:Price>
             <cbc:PriceAmount currencyID="AED">45000.00</cbc:PriceAmount>
             <cbc:BaseQuantity unitCode="EA">1</cbc:BaseQuantity>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_MarginScheme.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_MarginScheme.xml
@@ -100,21 +100,10 @@
             <cbc:TaxAmount currencyID="AED">0.00</cbc:TaxAmount>
         </cac:TaxTotal>
         <cac:Item>
-            <ext:UBLExtensions>
-                <ext:UBLExtension>
-                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ItemExtension</ext:ExtensionURI>
-                    <ext:ExtensionContent>
-                        <puf:PageroExtension>
-                            <puf:ItemExtension>
-                                <puf:ItemType>GOODS</puf:ItemType>
-                            </puf:ItemExtension>
-                        </puf:PageroExtension>
-                    </ext:ExtensionContent>
-                </ext:UBLExtension>
-            </ext:UBLExtensions>
-        <cbc:Description>Resold under the profit margin scheme — originally purchased from a non-Taxable individual. VIN 1HGCM82633A123456.</cbc:Description>
+            <cbc:Description>Resold under the profit margin scheme — originally purchased from a non-Taxable individual. VIN 1HGCM82633A123456.</cbc:Description>
             <cbc:Name>Used vehicle: 2022 Toyota Camry</cbc:Name>
             <cac:CommodityClassification>
+                <cbc:CommodityCode>G</cbc:CommodityCode>
                 <cbc:ItemClassificationCode listID="HS">8703.23.10</cbc:ItemClassificationCode>
             </cac:CommodityClassification>
             <cac:ClassifiedTaxCategory>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_NaturalPerson.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_NaturalPerson.xml
@@ -99,24 +99,17 @@
             <cbc:TaxAmount currencyID="AED">100.00</cbc:TaxAmount>
         </cac:TaxTotal>
         <cac:Item>
-            <ext:UBLExtensions>
-                <ext:UBLExtension>
-                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ItemExtension</ext:ExtensionURI>
-                    <ext:ExtensionContent>
-                        <puf:PageroExtension>
-                            <puf:ItemExtension>
-                                <puf:ItemType>SERVICES</puf:ItemType>
-                            </puf:ItemExtension>
-                        </puf:PageroExtension>
-                    </ext:ExtensionContent>
-                </ext:UBLExtension>
-            </ext:UBLExtensions>
             <cbc:Description>Independent consulting advice delivered by a natural-person service provider</cbc:Description>
             <cbc:Name>Q2 strategy consulting</cbc:Name>
             <cac:AdditionalItemIdentification>
                 <!-- BTAE-17 Service Accounting Code (mandatory when item type is SERVICES or BOTH) -->
                 <cbc:ID schemeID="SAC">9983.11</cbc:ID>
             </cac:AdditionalItemIdentification>
+            <!-- BTAE-13 Item type (G goods / S services / B both) carried via cac:CommodityClassification/cbc:CommodityCode -->
+            <cac:CommodityClassification>
+                <cbc:CommodityCode>S</cbc:CommodityCode>
+                <cbc:ItemClassificationCode listID="HS">8523.49.00</cbc:ItemClassificationCode>
+            </cac:CommodityClassification>
             <cac:ClassifiedTaxCategory>
                 <cbc:ID>S</cbc:ID>
                 <cbc:Percent>5.00</cbc:Percent>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_NaturalPerson.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_NaturalPerson.xml
@@ -1,4 +1,42 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+    PUF Invoice Example: Natural Person Seller (Passport Identification)
+
+    Use Case: A seller who is a natural person rather than a company. Instead of a trade
+              licence, the legal registration identifier is a passport number, which in
+              turn changes which supplementary identifier is required.
+
+    Country: United Arab Emirates
+    Format: PUF (Pagero Universal Format) 2.0
+    Document Type: Tax Invoice (Type 380)
+    Transaction Type: BTAE-02 = 00000000 (no special transaction context)
+    Target Format: Peppol PINT BIS Billing AE 1.0.4
+
+    Scenario Description:
+    Jane Doe, an independent consultant VAT-registered as a sole practitioner in Dubai,
+    invoices Burj Holdings PJSC (Abu Dhabi) for 10 hours of strategy consulting at
+    AED 200.00 per hour. Net AED 2,000.00 plus AED 100.00 VAT.
+
+    CRITICAL - PASSPORT CHANGES WHICH SUPPLEMENTARY FIELD IS REQUIRED:
+    Where the legal registration identifier type (BTAE-15) is a trade licence, Emirates ID
+    or Cabinet Decision, the authority name (BTAE-12) is required. Where it is a passport,
+    the passport issuing country code (BTAE-18) is required instead. Compare this example
+    with PUF_AE_Invoice.xml, which uses AE:TL and therefore carries AE:LRA.
+
+    Key Fields:
+    - BT-27 Seller name: the natural person's name
+    - BT-30 / BTAE-15 Legal registration identifier: passport number with
+      @schemeID="AE:PASSPORT"
+    - BTAE-18 Passport issuing country: mandatory when the identifier type is a passport
+      (ibr-012-ae). ISO 3166-1 alpha-2, carried on cac:PartyIdentification with
+      @schemeID="AE:PASSPORT_COUNTRY"
+    - BT-31 TRN: still present - a natural person can be VAT-registered as a sole trader
+    - BTAE-13 Item type S with SAC 9983.11 (management consulting services)
+
+    Reference: UAE Electronic Invoicing Guidelines V1.1 (1 June 2026);
+               PUF Code List PUF-008 Identification scheme United Arab Emirates;
+               Peppol PINT BIS Billing AE 1.0.4
+-->
 <Invoice xmlns:cac="urn:pagero:CommonAggregateComponents:1.0" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:puf="urn:pagero:ExtensionComponent:1.0" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns="urn:pagero:PageroUniversalFormat:Invoice:1.0">
     <cbc:CustomizationID>urn:pagero.com:puf:billing:2.0</cbc:CustomizationID>
     <cbc:ProfileID>urn:pagero.com:puf:billing:1.0</cbc:ProfileID>
@@ -10,7 +48,7 @@
     <cbc:DocumentCurrencyCode>AED</cbc:DocumentCurrencyCode>
     <cac:AccountingSupplierParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0235">100000000000003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000000</cbc:EndpointID>
             <!-- BTAE-18 Seller passport issuing country (mandatory when BTAE-15 legal-reg type is Passport).
                  Carried on cac:PartyIdentification with schemeID="AE:PASSPORT_COUNTRY". -->
             <cac:PartyIdentification>
@@ -41,7 +79,7 @@
     </cac:AccountingSupplierParty>
     <cac:AccountingCustomerParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0235">100000000001003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000100</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-11 Buyer legal registration authority (issuer of the trade license) -->
                 <cbc:ID schemeID="AE:LRA">Abu Dhabi Department of Economic Development</cbc:ID>
@@ -55,7 +93,7 @@
                 </cac:Country>
             </cac:PostalAddress>
             <cac:PartyTaxScheme>
-                <cbc:CompanyID>100000000001003</cbc:CompanyID>
+                <cbc:CompanyID>100000010001003</cbc:CompanyID>
                 <cac:TaxScheme>
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
@@ -69,6 +107,14 @@
     <cac:PaymentMeans>
         <!-- BT-81 Payment means type code: 30 = Credit transfer -->
         <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+            <!-- BT-84 Payment account identifier (IBAN). Mandatory when BT-81 is 30 (ibr-192-ae) -->
+            <cbc:ID>AE070331234567890123456</cbc:ID>
+            <cac:FinancialInstitutionBranch>
+                <!-- BT-86 BIC -->
+                <cbc:ID>EBILAEAD</cbc:ID>
+            </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
     </cac:PaymentMeans>
     <cac:TaxTotal>
         <cbc:TaxAmount currencyID="AED">100.00</cbc:TaxAmount>
@@ -108,7 +154,6 @@
             <!-- BTAE-13 Item type (G goods / S services / B both) carried via cac:CommodityClassification/cbc:CommodityCode -->
             <cac:CommodityClassification>
                 <cbc:CommodityCode>S</cbc:CommodityCode>
-                <cbc:ItemClassificationCode listID="HS">8523.49.00</cbc:ItemClassificationCode>
             </cac:CommodityClassification>
             <cac:ClassifiedTaxCategory>
                 <cbc:ID>S</cbc:ID>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_ReverseCharge.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_ReverseCharge.xml
@@ -97,25 +97,14 @@
             <cbc:TaxAmount currencyID="AED">0.00</cbc:TaxAmount>
         </cac:TaxTotal>
         <cac:Item>
-            <ext:UBLExtensions>
-                <ext:UBLExtension>
-                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ItemExtension</ext:ExtensionURI>
-                    <ext:ExtensionContent>
-                        <puf:PageroExtension>
-                            <puf:ItemExtension>
-                                <puf:ItemType>GOODS</puf:ItemType>
-                            </puf:ItemExtension>
-                        </puf:PageroExtension>
-                    </ext:ExtensionContent>
-                </ext:UBLExtension>
-            </ext:UBLExtensions>
-        <cbc:Description>Wholesale supply of mobile phones — domestic reverse-charge per UAE Cabinet Decision</cbc:Description>
+            <cbc:Description>Wholesale supply of mobile phones — domestic reverse-charge per UAE Cabinet Decision</cbc:Description>
             <cbc:Name>Smartphone, model X-Pro 5G</cbc:Name>
             <cac:StandardItemIdentification>
                 <cbc:ID schemeID="0160">06291041500001</cbc:ID>
             </cac:StandardItemIdentification>
             <cac:CommodityClassification>
                 <cbc:NatureCode>DL8.48.8.2</cbc:NatureCode>
+                <cbc:CommodityCode>G</cbc:CommodityCode>
                 <cbc:ItemClassificationCode listID="HS">8517.13.00</cbc:ItemClassificationCode>
             </cac:CommodityClassification>
             <cac:ClassifiedTaxCategory>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_ReverseCharge.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_ReverseCharge.xml
@@ -1,4 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+    PUF Invoice Example: Domestic Reverse Charge
+
+    Use Case: A domestic supply on which the buyer, not the seller, accounts for the VAT.
+              The seller charges no VAT; the buyer self-accounts under the reverse charge
+              mechanism.
+
+    Country: United Arab Emirates
+    Format: PUF (Pagero Universal Format) 2.0
+    Document Type: Tax Invoice (Type 380)
+    Transaction Type: BTAE-02 = 00000000 (reverse charge is signalled by the VAT category,
+                      not by a BTAE-02 flag)
+    Target Format: Peppol PINT BIS Billing AE 1.0.4
+
+    Scenario Description:
+    Acme Trading LLC (Dubai) supplies 25 smartphones at AED 200.00 each to Burj Holdings
+    PJSC (Abu Dhabi) under the domestic reverse charge mechanism. Net AED 5,000.00,
+    VAT AED 0.00, payable AED 5,000.00.
+
+    Key Fields:
+    - BT-151 / BT-118 VAT category: AE (VAT reverse charge)
+    - BT-48 Buyer VAT identifier: mandatory whenever a line carries category AE (ibr-103-ae)
+    - BTAE-08 Line VAT amount must be zero on reverse charge lines (ibr-162-ae)
+    - BTAE-09 Type of goods or services: mandatory for category AE (ibr-166-ae).
+      Carried on cac:CommodityClassification/cbc:NatureCode - note this is a different
+      element from BTAE-13 (cbc:CommodityCode), which sits in the same aggregate
+    - BT-157 Item standard identifier: mandatory on reverse charge lines, and the scheme
+      identifier BT-157-1 must be 0160 (GS1 GTIN) - ibr-174-ae
+    - A VAT breakdown with category AE must be present at document level (aligned-ibrp-ae-01-ae)
+
+    Reference: UAE Electronic Invoicing Guidelines V1.1 (1 June 2026);
+               Peppol PINT BIS Billing AE 1.0.4
+-->
 <Invoice xmlns:cac="urn:pagero:CommonAggregateComponents:1.0" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:puf="urn:pagero:ExtensionComponent:1.0" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns="urn:pagero:PageroUniversalFormat:Invoice:1.0">
     <cbc:CustomizationID>urn:pagero.com:puf:billing:2.0</cbc:CustomizationID>
     <cbc:ProfileID>urn:pagero.com:puf:billing:1.0</cbc:ProfileID>
@@ -9,7 +42,7 @@
     <cbc:DocumentCurrencyCode>AED</cbc:DocumentCurrencyCode>
     <cac:AccountingSupplierParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0235">100000000000003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000000</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-12 Seller legal registration authority (issuer of the trade license) -->
                 <cbc:ID schemeID="AE:LRA">Department of Economic Development - Dubai</cbc:ID>
@@ -36,7 +69,7 @@
     </cac:AccountingSupplierParty>
     <cac:AccountingCustomerParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0235">100000000001003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000100</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-11 Buyer legal registration authority (issuer of the trade license) -->
                 <cbc:ID schemeID="AE:LRA">Abu Dhabi Department of Economic Development</cbc:ID>
@@ -51,7 +84,7 @@
             </cac:PostalAddress>
             <cac:PartyTaxScheme>
                 <!-- Buyer VAT identifier mandatory for reverse-charge supplies (ibr-103-ae) -->
-                <cbc:CompanyID>100000000001003</cbc:CompanyID>
+                <cbc:CompanyID>100000010001003</cbc:CompanyID>
                 <cac:TaxScheme>
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
@@ -65,6 +98,14 @@
     <cac:PaymentMeans>
         <!-- BT-81 Payment means type code: 30 = Credit transfer -->
         <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+            <!-- BT-84 Payment account identifier (IBAN). Mandatory when BT-81 is 30 (ibr-192-ae) -->
+            <cbc:ID>AE070331234567890123456</cbc:ID>
+            <cac:FinancialInstitutionBranch>
+                <!-- BT-86 BIC -->
+                <cbc:ID>EBILAEAD</cbc:ID>
+            </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
     </cac:PaymentMeans>
     <cac:TaxTotal>
         <!-- VAT amount is 0 because the buyer accounts for the VAT under reverse charge -->
@@ -117,7 +158,7 @@
             </cac:ClassifiedTaxCategory>
             <!-- BTAE-09 RCM goods/services nature code (ibr-166-ae) — value from UAE Goods/Services subject to RCM code list -->
             <!-- ibr-174-ae: GS1 GTIN identifier mandatory on reverse-charge lines (schemeID="0160") -->
-            </cac:Item>
+        </cac:Item>
         <cac:Price>
             <cbc:PriceAmount currencyID="AED">200.00</cbc:PriceAmount>
             <cbc:BaseQuantity unitCode="EA">1</cbc:BaseQuantity>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_SummaryInvoice.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_SummaryInvoice.xml
@@ -1,4 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+    PUF Invoice Example: Summary Invoice
+
+    Use Case: Multiple transactions with the same customer over a defined invoicing period
+              consolidated onto a single summary invoice. The Guidelines cite a bank issuing
+              a monthly tax invoice summarising all supplies made as the worked example.
+
+    Country: United Arab Emirates
+    Format: PUF (Pagero Universal Format) 2.0
+    Document Type: Tax Invoice (Type 380)
+    Transaction Type: BTAE-02 = 00010000 (position 4 = Summary invoice)
+    Target Format: Peppol PINT BIS Billing AE 1.0.4
+
+    Scenario Description:
+    Emirates Premier Bank PJSC consolidates April 2026 banking fees for Burj Holdings PJSC
+    onto one invoice: the monthly account maintenance fee of AED 300.00 and 15 international
+    wire transfer fees totalling AED 450.00. Net AED 750.00 plus AED 37.50 VAT.
+
+    Key Fields:
+    - BTAE-02 position 4 = 1 flags the summary invoice context
+    - BG-14 InvoicePeriod: mandatory for summary invoices - it defines the consolidation
+      window (ibr-138-ae). This is the key structural requirement for this scenario
+    - Two service lines, each with its own SAC (BTAE-17): 9971.13 account maintenance,
+      9971.19 wire transfer fees
+    - BTAE-13 Item type S on both lines, which makes BTAE-17 mandatory (ibr-185-ae)
+
+    Note: If the consolidated total is negative (a net credit for the period), the
+    Guidelines require the transaction to be documented as an electronic Credit Note
+    rather than a summary invoice with a negative payable amount.
+
+    Reference: UAE Electronic Invoicing Guidelines V1.1 (1 June 2026), transaction type 4
+               (Summary invoice); Peppol PINT BIS Billing AE 1.0.4
+-->
 <Invoice xmlns:cac="urn:pagero:CommonAggregateComponents:1.0" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:puf="urn:pagero:ExtensionComponent:1.0" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns="urn:pagero:PageroUniversalFormat:Invoice:1.0">
     <cbc:CustomizationID>urn:pagero.com:puf:billing:2.0</cbc:CustomizationID>
     <cbc:ProfileID>urn:pagero.com:puf:billing:1.0</cbc:ProfileID>
@@ -16,7 +49,7 @@
     </cac:InvoicePeriod>
     <cac:AccountingSupplierParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0235">100000000000003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000000</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-12 Seller legal registration authority (issuer of the trade license) -->
                 <cbc:ID schemeID="AE:LRA">Department of Economic Development - Dubai</cbc:ID>
@@ -43,7 +76,7 @@
     </cac:AccountingSupplierParty>
     <cac:AccountingCustomerParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="0235">100000000001003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000100</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-11 Buyer legal registration authority (issuer of the trade license) -->
                 <cbc:ID schemeID="AE:LRA">Abu Dhabi Department of Economic Development</cbc:ID>
@@ -57,7 +90,7 @@
                 </cac:Country>
             </cac:PostalAddress>
             <cac:PartyTaxScheme>
-                <cbc:CompanyID>100000000001003</cbc:CompanyID>
+                <cbc:CompanyID>100000010001003</cbc:CompanyID>
                 <cac:TaxScheme>
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
@@ -71,6 +104,14 @@
     <cac:PaymentMeans>
         <!-- BT-81 Payment means type code: 30 = Credit transfer -->
         <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+            <!-- BT-84 Payment account identifier (IBAN). Mandatory when BT-81 is 30 (ibr-192-ae) -->
+            <cbc:ID>AE070331234567890123456</cbc:ID>
+            <cac:FinancialInstitutionBranch>
+                <!-- BT-86 BIC -->
+                <cbc:ID>EBILAEAD</cbc:ID>
+            </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
     </cac:PaymentMeans>
     <cac:TaxTotal>
         <cbc:TaxAmount currencyID="AED">37.50</cbc:TaxAmount>
@@ -108,16 +149,15 @@
             </cac:AdditionalItemIdentification>
             <cac:CommodityClassification>
                 <cbc:CommodityCode>S</cbc:CommodityCode>
-                <cbc:ItemClassificationCode listID="HS">8523.49.00</cbc:ItemClassificationCode>
             </cac:CommodityClassification>
-        <cac:ClassifiedTaxCategory>
+            <cac:ClassifiedTaxCategory>
                 <cbc:ID>S</cbc:ID>
                 <cbc:Percent>5.00</cbc:Percent>
                 <cac:TaxScheme>
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
             </cac:ClassifiedTaxCategory>
-            </cac:Item>
+        </cac:Item>
         <cac:Price>
             <cbc:PriceAmount currencyID="AED">300.00</cbc:PriceAmount>
             <cbc:BaseQuantity unitCode="EA">1</cbc:BaseQuantity>
@@ -145,16 +185,15 @@
             </cac:AdditionalItemIdentification>
             <cac:CommodityClassification>
                 <cbc:CommodityCode>S</cbc:CommodityCode>
-                <cbc:ItemClassificationCode listID="HS">8523.49.00</cbc:ItemClassificationCode>
             </cac:CommodityClassification>
-        <cac:ClassifiedTaxCategory>
+            <cac:ClassifiedTaxCategory>
                 <cbc:ID>S</cbc:ID>
                 <cbc:Percent>5.00</cbc:Percent>
                 <cac:TaxScheme>
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
             </cac:ClassifiedTaxCategory>
-            </cac:Item>
+        </cac:Item>
         <cac:Price>
             <cbc:PriceAmount currencyID="AED">30.00</cbc:PriceAmount>
             <cbc:BaseQuantity unitCode="EA">1</cbc:BaseQuantity>

--- a/examples/country-specific-examples/uae/PUF_AE_Invoice_SummaryInvoice.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_Invoice_SummaryInvoice.xml
@@ -101,23 +101,15 @@
             <cbc:TaxAmount currencyID="AED">15.00</cbc:TaxAmount>
         </cac:TaxTotal>
         <cac:Item>
-            <ext:UBLExtensions>
-                <ext:UBLExtension>
-                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ItemExtension</ext:ExtensionURI>
-                    <ext:ExtensionContent>
-                        <puf:PageroExtension>
-                            <puf:ItemExtension>
-                                <puf:ItemType>SERVICES</puf:ItemType>
-                            </puf:ItemExtension>
-                        </puf:PageroExtension>
-                    </ext:ExtensionContent>
-                </ext:UBLExtension>
-            </ext:UBLExtensions>
             <cbc:Description>April 2026 — corporate current account</cbc:Description>
             <cbc:Name>Monthly account maintenance fee</cbc:Name>
             <cac:AdditionalItemIdentification>
                 <cbc:ID schemeID="SAC">9971.13</cbc:ID>
             </cac:AdditionalItemIdentification>
+            <cac:CommodityClassification>
+                <cbc:CommodityCode>S</cbc:CommodityCode>
+                <cbc:ItemClassificationCode listID="HS">8523.49.00</cbc:ItemClassificationCode>
+            </cac:CommodityClassification>
         <cac:ClassifiedTaxCategory>
                 <cbc:ID>S</cbc:ID>
                 <cbc:Percent>5.00</cbc:Percent>
@@ -146,23 +138,15 @@
             <cbc:TaxAmount currencyID="AED">22.50</cbc:TaxAmount>
         </cac:TaxTotal>
         <cac:Item>
-            <ext:UBLExtensions>
-                <ext:UBLExtension>
-                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ItemExtension</ext:ExtensionURI>
-                    <ext:ExtensionContent>
-                        <puf:PageroExtension>
-                            <puf:ItemExtension>
-                                <puf:ItemType>SERVICES</puf:ItemType>
-                            </puf:ItemExtension>
-                        </puf:PageroExtension>
-                    </ext:ExtensionContent>
-                </ext:UBLExtension>
-            </ext:UBLExtensions>
             <cbc:Description>15 cross-border transfers processed in April 2026</cbc:Description>
             <cbc:Name>International wire transfer fee</cbc:Name>
             <cac:AdditionalItemIdentification>
                 <cbc:ID schemeID="SAC">9971.19</cbc:ID>
             </cac:AdditionalItemIdentification>
+            <cac:CommodityClassification>
+                <cbc:CommodityCode>S</cbc:CommodityCode>
+                <cbc:ItemClassificationCode listID="HS">8523.49.00</cbc:ItemClassificationCode>
+            </cac:CommodityClassification>
         <cac:ClassifiedTaxCategory>
                 <cbc:ID>S</cbc:ID>
                 <cbc:Percent>5.00</cbc:Percent>

--- a/examples/country-specific-examples/uae/PUF_AE_SelfBilling_Invoice.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_SelfBilling_Invoice.xml
@@ -108,21 +108,10 @@
             <cbc:TaxAmount currencyID="AED">175.00</cbc:TaxAmount>
         </cac:TaxTotal>
         <cac:Item>
-            <ext:UBLExtensions>
-                <ext:UBLExtension>
-                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ItemExtension</ext:ExtensionURI>
-                    <ext:ExtensionContent>
-                        <puf:PageroExtension>
-                            <puf:ItemExtension>
-                                <puf:ItemType>GOODS</puf:ItemType>
-                            </puf:ItemExtension>
-                        </puf:PageroExtension>
-                    </ext:ExtensionContent>
-                </ext:UBLExtension>
-            </ext:UBLExtensions>
-        <cbc:Description>Self-billed purchase of 7 tonnes of mixed ferrous scrap (delivery weighed at buyer's gate)</cbc:Description>
+            <cbc:Description>Self-billed purchase of 7 tonnes of mixed ferrous scrap (delivery weighed at buyer's gate)</cbc:Description>
             <cbc:Name>Mixed ferrous scrap metal</cbc:Name>
             <cac:CommodityClassification>
+                <cbc:CommodityCode>G</cbc:CommodityCode>
                 <cbc:ItemClassificationCode listID="HS">7204.49.00</cbc:ItemClassificationCode>
             </cac:CommodityClassification>
             <cac:ClassifiedTaxCategory>

--- a/examples/country-specific-examples/uae/PUF_AE_SelfBilling_Invoice.xml
+++ b/examples/country-specific-examples/uae/PUF_AE_SelfBilling_Invoice.xml
@@ -1,4 +1,43 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+    PUF Invoice Example: Self-Billed Invoice
+
+    Use Case: The buyer issues the invoice on the supplier's behalf. Common where only the
+              buyer can determine the invoiced quantity at the point of receipt - scrap
+              metal, agricultural produce, or other weighed or graded goods.
+
+    Country: United Arab Emirates
+    Format: PUF (Pagero Universal Format) 2.0
+    Document Type: Tax Invoice (Type 380) in PUF - see the note on the target format below
+    Transaction Type: BTAE-02 = 00000000 (no special transaction context)
+    Target Format: Peppol PINT BIS Self-Billing AE 1.0.4
+
+    Scenario Description:
+    Emirates Steel Recycling LLC (Sharjah) receives 7 tonnes of mixed ferrous scrap from
+    Al Awir Scrap Suppliers LLC (Dubai) at AED 500.00 per tonne. The scrap is weighed at
+    the recycler's gate, so the recycler - the buyer - raises the invoice. Net AED 3,500.00
+    plus AED 175.00 VAT.
+
+    CRITICAL - PARTY ROLES ARE NOT REVERSED:
+    AccountingSupplierParty remains the supplier whose supply is being invoiced (Al Awir)
+    and AccountingCustomerParty remains the buyer (Emirates Steel), exactly as on a normal
+    invoice. Self-billing is signalled only by the puf:SelfBilled flag - do not swap the
+    parties.
+
+    Key Fields:
+    - puf:SelfBilled = true: document-level PUF extension marking the self-billing case
+    - BT-3 Type code stays 380 in PUF; UAE has no separate PUF self-billing type code
+    - BTAE-13 Item type G with HS 7204.49.00 (ferrous waste and scrap)
+
+    Note on the target mapping: the transformation to PINT AE applies type code 389
+    (self-billed invoice) and the CustomizationID urn:peppol:pint:selfbilling-1@ae-1
+    automatically. The specification identifier must start with either
+    urn:peppol:pint:billing-1@ae-1 or urn:peppol:pint:selfbilling-1@ae-1
+    (aligned-ibrp-001-ae), so the correct value is chosen at transformation time.
+
+    Reference: UAE Electronic Invoicing Guidelines V1.1 (1 June 2026);
+               Peppol PINT BIS Self-Billing AE 1.0.4
+-->
 <Invoice xmlns:cac="urn:pagero:CommonAggregateComponents:1.0" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:puf="urn:pagero:ExtensionComponent:1.0" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns="urn:pagero:PageroUniversalFormat:Invoice:1.0">
     <ext:UBLExtensions>
         <!-- Self-billing indicator -->
@@ -22,7 +61,7 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <!-- Supplier: the legal counterparty whose supply is being invoiced -->
-            <cbc:EndpointID schemeID="0235">100000000000003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000000</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-12 Seller legal registration authority (issuer of the trade license) -->
                 <cbc:ID schemeID="AE:LRA">Department of Economic Development - Dubai</cbc:ID>
@@ -50,7 +89,7 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <!-- Buyer: the party that ACTUALLY issues this self-billed invoice -->
-            <cbc:EndpointID schemeID="0235">100000000001003</cbc:EndpointID>
+            <cbc:EndpointID schemeID="0235">1000000100</cbc:EndpointID>
             <cac:PartyIdentification>
                 <!-- BTAE-11 Buyer legal registration authority (issuer of the trade license) -->
                 <cbc:ID schemeID="AE:LRA">Sharjah Economic Development Department</cbc:ID>
@@ -64,7 +103,7 @@
                 </cac:Country>
             </cac:PostalAddress>
             <cac:PartyTaxScheme>
-                <cbc:CompanyID>100000000001003</cbc:CompanyID>
+                <cbc:CompanyID>100000010001003</cbc:CompanyID>
                 <cac:TaxScheme>
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
@@ -78,6 +117,15 @@
     <cac:PaymentMeans>
         <!-- BT-81 Payment means type code: 30 = Credit transfer -->
         <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+            <!-- BT-84 Payment account identifier (IBAN). Mandatory when BT-81 is 30 (ibr-192-ae).
+                 The payee is the supplier (Al Awir), even though the buyer raises this invoice. -->
+            <cbc:ID>AE070331234567890123456</cbc:ID>
+            <cac:FinancialInstitutionBranch>
+                <!-- BT-86 BIC -->
+                <cbc:ID>EBILAEAD</cbc:ID>
+            </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
     </cac:PaymentMeans>
     <cac:TaxTotal>
         <cbc:TaxAmount currencyID="AED">175.00</cbc:TaxAmount>
@@ -121,7 +169,7 @@
                     <cbc:ID>VAT</cbc:ID>
                 </cac:TaxScheme>
             </cac:ClassifiedTaxCategory>
-            </cac:Item>
+        </cac:Item>
         <cac:Price>
             <cbc:PriceAmount currencyID="AED">500.00</cbc:PriceAmount>
             <cbc:BaseQuantity unitCode="TNE">1</cbc:BaseQuantity>

--- a/examples/country-specific-examples/uae/README.md
+++ b/examples/country-specific-examples/uae/README.md
@@ -8,10 +8,13 @@ UAE e-invoicing is mandated through the Federal Tax Authority (FTA) and transmit
 
 - Invoice Transaction Type Code (BTAE-02) — 8-character flag string signalling the UAE business context
 - UAE Tax Registration Number (TRN) — 15-digit identifier starting with `1` and ending with `03`
+- Peppol Participant Identifier — the 10-digit TIN (first 10 digits of the TRN) under scheme `0235`
 - Legal registration identifiers — Trade License, Emirates ID, Passport (scheme codes `AE:TL`, `AE:EID`, `AE:PASSPORT`)
 - Emirate codes for country subdivision (`AUH`, `DXB`, `SHJ`, `UAQ`, `FUJ`, `AJM`, `RAK`)
 - Item type declaration via `cac:CommodityClassification/cbc:CommodityCode` (`G`, `S`, `B`) with HS classification and SAC codes
 - UAE-specific supply scenarios: exports, Free Trade Zone, disclosed agent, deemed supply, profit margin scheme
+
+> Each XML file opens with a header comment describing the use case, the scenario, the key fields and the governing rule references, so an example can be read on its own without this README. The sections below give the same information in summary form for scanning and comparison.
 
 ---
 
@@ -304,6 +307,28 @@ Demonstrates:
 
 ---
 
+### 15. PUF_AE_Invoice_NaturalPerson.xml
+
+**Natural Person Seller (Passport Identification)**
+
+Demonstrates:
+
+- A seller who is a natural person rather than a company
+- Legal registration identifier is a passport number (`AE:PASSPORT`) instead of a trade license
+- Passport issuing country code (BTAE-18) required in place of the authority name (BTAE-12)
+- A natural person can still be VAT-registered as a sole practitioner and carry a TRN
+
+**Key Features:**
+
+- Document type: `380`, BTAE-02 `00000000`
+- Seller: Jane Doe (Dubai, DXB) — passport `P12345678` with `@schemeID="AE:PASSPORT"`
+- BTAE-18 passport issuing country `GB` on `cac:PartyIdentification` with `@schemeID="AE:PASSPORT_COUNTRY"` (ibr-012-ae)
+- 10 hours of consulting at AED 200.00/hour; item type `S`, SAC `9983.11`
+
+> **Which supplementary field applies:** when the legal registration identifier type (BTAE-15) is `AE:TL`, `AE:EID` or `AE:CD`, the authority name (BTAE-12) is required. When it is `AE:PASSPORT`, the passport issuing country (BTAE-18) is required instead. Compare this example with `PUF_AE_Invoice.xml`.
+
+---
+
 ## UAE-Specific Requirements Reference
 
 ### BTAE-02 Invoice Transaction Type Code
@@ -340,12 +365,25 @@ Eight-character flag string in `cbc:InvoiceTypeCode/@name` (or `cbc:CreditNoteTy
 | Services | `S` | SAC (`cac:AdditionalItemIdentification/@schemeID = 'SAC'`) | e.g. `9983.11` |
 | Mixed | `B` | Both HS and SAC | — |
 
+> **Service lines carry no HS code.** The PINT AE syntax table shows `cbc:ItemClassificationCode` as 1..1 inside `cac:CommodityClassification`, but the schematron only requires it when the item type is `G` or `B` (`ibr-184-ae`), and `ibr-188-ae` constrains the scheme only when a classification is present. A pure service line therefore contains `cbc:CommodityCode` alone — verified end-to-end against PINT AE 1.0.4. HS classifies goods; putting a placeholder HS code on a service would misreport the supply.
+
 ### Fixed Placeholder Endpoints
 
 | Scenario | Buyer EndpointID (scheme `0235`) |
 |----------|----------------------------------|
 | Deemed Supply | `9900000097` |
 | Export to non-Peppol buyer | `9900000099` |
+
+### Participant Identifier (EndpointID)
+
+The seller and buyer `cbc:EndpointID` is the Peppol Participant Identifier issued by the FTA: the **10-digit TIN** under scheme `0235`. The TIN is the first 10 digits of the 15-character TRN — the full TRN must **not** be used as the endpoint.
+
+| Party | TRN (`cac:PartyTaxScheme/cbc:CompanyID`) | EndpointID (scheme `0235`) |
+|-------|------------------------------------------|----------------------------|
+| Seller (Acme Trading LLC) | `100000000000003` | `1000000000` |
+| Buyer (Burj Holdings PJSC) | `100000010001003` | `1000000100` |
+
+The PUF-008 scheme code `AE:TIN` is used on `cac:PartyIdentification/cbc:ID`, not on `cbc:EndpointID`.
 
 ### TRN Format
 

--- a/examples/country-specific-examples/uae/README.md
+++ b/examples/country-specific-examples/uae/README.md
@@ -10,7 +10,7 @@ UAE e-invoicing is mandated through the Federal Tax Authority (FTA) and transmit
 - UAE Tax Registration Number (TRN) — 15-digit identifier starting with `1` and ending with `03`
 - Legal registration identifiers — Trade License, Emirates ID, Passport (scheme codes `AE:TL`, `AE:EID`, `AE:PASSPORT`)
 - Emirate codes for country subdivision (`AUH`, `DXB`, `SHJ`, `UAQ`, `FUJ`, `AJM`, `RAK`)
-- Item type declaration (`GOODS`, `SERVICES`, `BOTH`) with HS classification and SAC codes
+- Item type declaration via `cac:CommodityClassification/cbc:CommodityCode` (`G`, `S`, `B`) with HS classification and SAC codes
 - UAE-specific supply scenarios: exports, Free Trade Zone, disclosed agent, deemed supply, profit margin scheme
 
 ---
@@ -26,7 +26,7 @@ Demonstrates:
 - Standard UAE tax invoice with 5% VAT (category `S`)
 - BTAE-02 = `00000000` (no special transaction context)
 - Seller TRN and trade license with Legal Registration Authority (LRA)
-- HS classification for goods (BTAE-13 = `GOODS`)
+- HS classification for goods (BTAE-13 = `G`)
 - UAE IBAN and BIC in PayeeFinancialAccount
 
 **Key Features:**
@@ -74,7 +74,7 @@ Demonstrates:
 - Document type: `380`, BTAE-02 `00001000`
 - InvoicePeriod: April 2026 (monthly advisory retainer)
 - ContractDocumentReference: MSA-2025-ACME-BURJ-007
-- Item type `SERVICES`, SAC code `9983.11` (Management consulting services)
+- Item type `S` (Services), SAC code `9983.11` (Management consulting services)
 
 ---
 
@@ -334,11 +334,11 @@ Eight-character flag string in `cbc:InvoiceTypeCode/@name` (or `cbc:CreditNoteTy
 
 ### Item Type and Classification
 
-| Scenario | `puf:ItemType` | Classification required | Code |
-|----------|---------------|------------------------|------|
-| Physical goods | `GOODS` | HS (`@listID = 'HS'`) | e.g. `8413.70.10` |
-| Services | `SERVICES` | SAC (`cac:AdditionalItemIdentification/@schemeID = 'SAC'`) | e.g. `9983.11` |
-| Mixed | `BOTH` | Both HS and SAC | — |
+| Scenario | `cbc:CommodityCode` | Classification required | Code |
+|----------|---------------------|------------------------|------|
+| Physical goods | `G` | HS (`@listID = 'HS'`) | e.g. `8413.70.10` |
+| Services | `S` | SAC (`cac:AdditionalItemIdentification/@schemeID = 'SAC'`) | e.g. `9983.11` |
+| Mixed | `B` | Both HS and SAC | — |
 
 ### Fixed Placeholder Endpoints
 

--- a/index.html
+++ b/index.html
@@ -8,21 +8,23 @@
 <meta name="author" content="Copyright &copy; 2025, Pagero, Part of Thomson Reuters">
 <meta name="copyright" content="Pagero, Part of Thomson Reuters">
 <title>PUF Billing 2.0</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
-/* Uncomment the following line when using as a custom stylesheet */
-/* @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"; */
-html{font-family:sans-serif;-webkit-text-size-adjust:100%}
-a{background:none}
+/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
+audio,canvas,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+[hidden],template{display:none}
+script{display:none!important}
+html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
+a{background:transparent}
 a:focus{outline:thin dotted}
 a:active,a:hover{outline:0}
 h1{font-size:2em;margin:.67em 0}
+abbr[title]{border-bottom:1px dotted}
 b,strong{font-weight:bold}
-abbr{font-size:.9em}
-abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
 dfn{font-style:italic}
-hr{height:0}
+hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
 mark{background:#ff0;color:#000}
 code,kbd,pre,samp{font-family:monospace;font-size:1em}
 pre{white-space:pre-wrap}
@@ -34,22 +36,22 @@ sub{bottom:-.25em}
 img{border:0}
 svg:not(:root){overflow:hidden}
 figure{margin:0}
-audio,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
 fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
 legend{border:0;padding:0}
 button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
 button,input{line-height:normal}
 button,select{text-transform:none}
-button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
+button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
 button[disabled],html input[disabled]{cursor:default}
-input[type=checkbox],input[type=radio]{padding:0}
+input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
+input[type="search"]{-webkit-appearance:textfield;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;box-sizing:content-box}
+input[type="search"]::-webkit-search-cancel-button,input[type="search"]::-webkit-search-decoration{-webkit-appearance:none}
 button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
 textarea{overflow:auto;vertical-align:top}
 table{border-collapse:collapse;border-spacing:0}
-*,::before,::after{box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+*,*:before,*:after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
+html,body{font-size:95%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
 a:hover{cursor:pointer}
 img,object,embed{max-width:100%;height:auto}
 object,embed{height:100%}
@@ -64,65 +66,69 @@ img{-ms-interpolation-mode:bicubic}
 img,object,svg{display:inline-block;vertical-align:middle}
 textarea{height:auto;min-height:50px}
 select{width:100%}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
+.center{margin-left:auto;margin-right:auto}
+.spread{width:100%}
+.stretch{width:100%}
+p.lead,.paragraph.lead>p,#preamble>.sectionbody>.paragraph:first-of-type p{font-size:1.21875em;line-height:1.6}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#0d603d;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr;border-bottom: ;}
 a{color:#2156a5;text-decoration:underline;line-height:inherit}
 a:hover,a:focus{color:#1d4b8f}
-a img{border:0}
-p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+a img{border:none}
+p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
 p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#0d603d;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#0d603d;line-height:0}
 h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
+h2{font-size:1.6875em;}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em;border-top:1px solid #ddddd8}
+h4,h5{font-size:1.125em;border-top:1px solid #ddddd8}
+h6{font-size:1em;border-top:1px solid #ddddd8}
+hr{border:solid #ddddd8;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
 em,i{font-style:italic;line-height:inherit}
 strong,b{font-weight:bold;line-height:inherit}
 small{font-size:60%;line-height:inherit}
 code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
 ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
+ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
+ul.square{list-style-type:square}
 ul.circle{list-style-type:circle}
 ul.disc{list-style-type:disc}
-ul.square{list-style-type:square}
-ul.circle ul:not([class]),ul.disc ul:not([class]),ul.square ul:not([class]){list-style:inherit}
 ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
 dl dt{margin-bottom:.3125em;font-weight:bold}
 dl dd{margin-bottom:1.25em}
+abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
+abbr{text-transform:none}
 blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
+blockquote cite:before{content:"\2014 \0020"}
+blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
 blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+@media only screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
 h1{font-size:2.75em}
 h2{font-size:2.3125em}
 h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
 h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
-table thead,table tfoot{background:#f7f8f7}
+table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
+table thead,table tfoot{background:#f7f8f7;font-weight:bold}
 table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
 table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+table tr.even,table tr.alt,table tr:nth-of-type(even){background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em; padding: 2rem 0 1rem 0;}
 h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
-.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
-.clearfix::after,.float-group::after{clear:both}
-:not(pre).nobreak{word-wrap:normal}
-:not(pre).nowrap{white-space:nowrap}
-:not(pre).pre-wrap{white-space:pre-wrap}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
-pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
-pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
-pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+.clearfix:before,.clearfix:after,.float-group:before,.float-group:after{content:" ";display:table}
+.clearfix:after,.float-group:after{clear:both}
+*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
+*:not(pre)>code.nobreak{word-wrap:normal}
+*:not(pre)>code.nowrap{white-space:nowrap}
+pre,pre>code{line-height:1.45;color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;text-rendering:optimizeSpeed}
 em em{font-style:normal}
 strong strong{font-weight:400}
 .keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background-color:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
 .keyseq kbd:first-child{margin-left:0}
 .keyseq kbd:last-child{margin-right:0}
 .menuseq,.menuref{color:#000}
@@ -130,151 +136,139 @@ kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-bl
 .menuseq{word-spacing:-.02em}
 .menuseq b.caret{font-size:1.25em;line-height:.8}
 .menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
-b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
-b.button::before{content:"[";padding:0 3px 0 2px}
-b.button::after{content:"]";padding:0 2px 0 3px}
+b.button:before,b.button:after{position:relative;top:-1px;font-weight:400}
+b.button:before{content:"[";padding:0 3px 0 2px}
+b.button:after{content:"]";padding:0 2px 0 3px}
 p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
-#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header:before,#header:after,#content:before,#content:after,#footnotes:before,#footnotes:after,#footer:before,#footer:after{content:" ";display:table}
+#header:after,#content:after,#footnotes:after,#footer:after{clear:both}
 #content{margin-top:1.25em}
-#content::before{content:none}
+#content:before{content:none}
 #header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child{border-bottom:1px solid #dddddf;padding-bottom:8px}
-#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #ddddd8}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #ddddd8;padding-bottom:8px}
+details>summary:first-of-type{cursor:pointer;display:list-item;outline:none;margin-bottom:.75em}
+#header .details{border-bottom:1px solid #ddddd8;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
 #header .details span:first-child{margin-left:-.125em}
 #header .details span.email a{color:rgba(0,0,0,.85)}
 #header .details br{display:none}
-#header .details br+span::before{content:"\00a0\2013\00a0"}
-#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header .details br+span:before{content:"\00a0\2013\00a0"}
+#header .details br+span.author:before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark:before{content:"\00a0|\00a0"}
 #header #revnumber{text-transform:capitalize}
-#header #revnumber::after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#header #revnumber:after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #ddddd8;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{background-color:#183c34;border-bottom:1px solid #efefed;padding-bottom:.5em}
 #toc>ul{margin-left:.125em}
 #toc ul.sectlevel0>li>a{font-style:italic}
 #toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
 #toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
 #toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
+#toc a{text-decoration:none;color:#dddddd}
 #toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+#toctitle{color:#dddddd;font-size:1.2em;border-top:none!important;padding:0;}
+@media only screen and (min-width:768px){#toctitle{font-size:1.375em}
 body.toc2{padding-left:15em;padding-right:0}
-body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
-#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2{margin-top:0!important;background-color:#183c34;position:fixed;width:15em;left:0;top:0;border-right:1px solid #efefed;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
 #toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0;}
 #toc.toc2 ul ul{margin-left:0;padding-left:1em}
 #toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
 body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
-@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #efefed;left:auto;right:0}}
+@media only screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:auto}
 #toc.toc2 #toctitle{font-size:1.375em}
 #toc.toc2>ul{font-size:.95em}
 #toc.toc2 ul ul{padding-left:1.25em}
 body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
+#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
 #content #toc>:first-child{margin-top:0}
 #content #toc>:last-child{margin-bottom:0}
-#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
-#content{margin-bottom:.625em}
+#footer{max-width:100%;background-color:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
 .sect1{padding-bottom:.625em}
-@media screen and (min-width:768px){#content{margin-bottom:1.25em}
-.sect1{padding-bottom:1.25em}}
-.sect1:last-child{padding-bottom:0}
-.sect1+.sect1{border-top:1px solid #e7e7e9}
+@media only screen and (min-width:768px){.sect1{padding-bottom:1.25em}}
+.sect1+.sect1{border-top:1px solid #efefed}
 #content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1>a.anchor:before,h2>a.anchor:before,h3>a.anchor:before,#toctitle>a.anchor:before,.sidebarblock>.content>.title>a.anchor:before,h4>a.anchor:before,h5>a.anchor:before,h6>a.anchor:before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em;color: #0d603d}
 #content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-details{margin-left:1.25rem}
-details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
-details>summary::-webkit-details-marker{display:none}
-details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
-details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
-details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#0d603d;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#0d603d}
+.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
 .admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
-.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+table.tableblock>caption.title{white-space:nowrap;overflow:visible;max-width:0}
+.paragraph.lead>p,#preamble>.sectionbody>.paragraph:first-of-type p{color:rgba(0,0,0,.85)}
+table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p{font-size:inherit}
 .admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
 .admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon img{max-width:initial}
 .admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #ddddd8;color:rgba(0,0,0,.6)}
 .admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
-.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
+.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
 .sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:first-child,.sidebarblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child,.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
-@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
-@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
-.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
-.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
-.listingblock>.content{position:relative}
-.listingblock pre>code{display:block}
-.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
-.listingblock:hover code[data-lang]::before{display:block}
-.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
-.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock pre:not(.highlight),.listingblock pre[class="highlight"],.listingblock pre[class^="highlight "],.listingblock pre.CodeRay,.listingblock pre.prettyprint{background:#f7f7f8}
+.sidebarblock .literalblock pre,.sidebarblock .listingblock pre:not(.highlight),.sidebarblock .listingblock pre[class="highlight"],.sidebarblock .listingblock pre[class^="highlight "],.sidebarblock .listingblock pre.CodeRay,.sidebarblock .listingblock pre.prettyprint{background:#f2f1f1}
+.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;padding:1em;font-size:.8125em}
+.literalblock pre.nowrap,.literalblock pre[class].nowrap,.listingblock pre.nowrap,.listingblock pre[class].nowrap{overflow-x:auto;white-space:pre;word-wrap:normal}
+@media only screen and (min-width:768px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:.90625em}}
+@media only screen and (min-width:1280px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:1em}}
+.literalblock.output pre{color:#f7f7f8;background-color:rgba(0,0,0,.9)}
 .listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
+.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
 .listingblock pre.prettyprint{border-width:0}
-.prettyprint{background:#f7f7f8}
-pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
-pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
-pre.prettyprint li code[data-lang]::before{opacity:1}
-pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
-table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
-table.linenotable td.code{padding-left:.75em}
-table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
-pre.pygments span.linenos{display:inline-block;margin-right:.75em}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]:before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:#999}
+.listingblock:hover code[data-lang]:before{display:block}
+.listingblock.terminal pre .command:before{content:attr(data-prompt);padding-right:.5em;color:#999}
+.listingblock.terminal pre .command:not([data-prompt]):before{content:"$"}
+table.pyhltable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.pyhltable td{vertical-align:top;padding-top:0;padding-bottom:0;line-height:1.45}
+table.pyhltable td.code{padding-left:.75em;padding-right:0}
+pre.pygments .lineno,table.pyhltable td:not(.code){color:#999;padding-left:0;padding-right:.5em;border-right:1px solid #ddddd8}
+pre.pygments .lineno{display:inline-block;margin-right:.25em}
+table.pyhltable .linenodiv{background:none!important;padding-right:0!important}
 .quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock blockquote p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
 .quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote:before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
 .quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
-.verseblock{margin:0 1em 1.25em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.quoteblock .attribution{margin-top:.5em;margin-right:.5ex;text-align:right}
+.quoteblock .quoteblock{margin-left:0;margin-right:0;padding:.5em 0;border-left:3px solid rgba(0,0,0,.6)}
+.quoteblock .quoteblock blockquote{padding:0 0 0 .75em}
+.quoteblock .quoteblock blockquote:before{display:none}
+.verseblock{margin:0 1em 1.25em 1em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
 .verseblock pre strong{font-weight:400}
 .verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
 .quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
 .quoteblock .attribution br,.verseblock .attribution br{display:none}
 .quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
-.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
-.quoteblock.abstract{margin:0 1em 1.25em;display:block}
-.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
-.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
-.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
-.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
-.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
-p.tableblock:last-child{margin-bottom:0}
-td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
-td.tableblock>.content>:last-child{margin-bottom:-1.25em}
+.quoteblock.abstract{margin:0 0 1.25em 0;display:block}
+.quoteblock.abstract blockquote,.quoteblock.abstract blockquote p{text-align:left;word-spacing:0}
+.quoteblock.abstract blockquote:before,.quoteblock.abstract blockquote p:first-of-type:before{display:none}
+table.tableblock{max-width:100%;border-collapse:separate}
+table.tableblock td>.paragraph:last-child p>p:last-child,table.tableblock th>p:last-child,table.tableblock td>p:last-child{margin-bottom:0}
 table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>*>tr>*{border-width:1px}
-table.grid-cols>*>tr>*{border-width:0 1px}
-table.grid-rows>*>tr>*{border-width:1px 0}
+table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
+table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
+table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
+table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px 0}
+table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0 0}
+table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
+table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
 table.frame-all{border-width:1px}
-table.frame-ends{border-width:1px 0}
 table.frame-sides{border-width:0 1px}
-table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
-table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
-table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
-table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
-table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
+table.frame-topbot{border-width:1px 0}
 th.halign-left,td.halign-left{text-align:left}
 th.halign-right,td.halign-right{text-align:right}
 th.halign-center,td.halign-center{text-align:center}
@@ -282,24 +276,25 @@ th.valign-top,td.valign-top{vertical-align:top}
 th.valign-bottom,td.valign-bottom{vertical-align:bottom}
 th.valign-middle,td.valign-middle{vertical-align:middle}
 table thead th,table tfoot th{font-weight:bold}
-tbody tr th{background:#f7f8f7}
+tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
 tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
 p.tableblock>code:only-child{background:none;padding:0}
 p.tableblock{font-size:1em}
+td>div.verse{white-space:pre}
 ol{margin-left:1.75em}
 ul li ol{margin-left:1.5em}
 dl dd{margin-left:1.125em}
 dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
 ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
 ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
 ul.unstyled,ol.unstyled{margin-left:0}
-li>p:empty:only-child::before{content:"";display:inline-block}
-ul.checklist>li>p:first-child{margin-left:-1em}
-ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
-ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
-ul.inline>li{margin-left:1.25em}
+ul.checklist{margin-left:.625em}
+ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
+ul.inline{margin:0 auto .625em auto;margin-left:-1.375em;margin-right:0;padding:0;list-style:none;overflow:hidden}
+ul.inline>li{list-style:none;float:left;margin-left:1.375em;display:block}
+ul.inline>li>*{display:block}
 .unstyled dl dt{font-weight:400;font-style:normal}
 ol.arabic{list-style-type:decimal}
 ol.decimal{list-style-type:decimal-leading-zero}
@@ -312,14 +307,13 @@ ol.lowergreek{list-style-type:lower-greek}
 .hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
 td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
 td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-td.hdlist2{word-wrap:anywhere}
 .literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
-.colist td:not([class]):first-child img{max-width:none}
-.colist td:not([class]):last-child{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
-.imageblock.left{margin:.25em .625em 1.25em 0}
-.imageblock.right{margin:.25em 0 1.25em .625em}
+.colist>table tr>td:first-of-type{padding:.4em .75em 0 .75em;line-height:1;vertical-align:top}
+.colist>table tr>td:first-of-type img{max-width:initial}
+.colist>table tr>td:last-of-type{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
+.imageblock.left,.imageblock[style*="float: left"]{margin:.25em .625em 1.25em 0}
+.imageblock.right,.imageblock[style*="float: right"]{margin:.25em 0 1.25em .625em}
 .imageblock>.title{margin-bottom:0}
 .imageblock.thumb,.imageblock.th{border-width:6px}
 .imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
@@ -330,13 +324,15 @@ a.image{text-decoration:none;display:inline-block}
 a.image object{pointer-events:none}
 sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
 sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active,#footnotes .footnote a:first-of-type:active{text-decoration:underline}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
 #footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em 0;border-width:1px 0 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;text-indent:-1.05em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none}
 #footnotes .footnote:last-of-type{margin-bottom:0}
 #content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
+.gist .file-data>table td.line-data{width:99%}
 div.unbreakable{page-break-inside:avoid}
 .big{font-size:larger}
 .small{font-size:smaller}
@@ -344,96 +340,92 @@ div.unbreakable{page-break-inside:avoid}
 .overline{text-decoration:overline}
 .line-through{text-decoration:line-through}
 .aqua{color:#00bfbf}
-.aqua-background{background:#00fafa}
+.aqua-background{background-color:#00fafa}
 .black{color:#000}
-.black-background{background:#000}
+.black-background{background-color:#000}
 .blue{color:#0000bf}
-.blue-background{background:#0000fa}
+.blue-background{background-color:#0000fa}
 .fuchsia{color:#bf00bf}
-.fuchsia-background{background:#fa00fa}
+.fuchsia-background{background-color:#fa00fa}
 .gray{color:#606060}
-.gray-background{background:#7d7d7d}
+.gray-background{background-color:#7d7d7d}
 .green{color:#006000}
-.green-background{background:#007d00}
+.green-background{background-color:#007d00}
 .lime{color:#00bf00}
-.lime-background{background:#00fa00}
+.lime-background{background-color:#00fa00}
 .maroon{color:#600000}
-.maroon-background{background:#7d0000}
+.maroon-background{background-color:#7d0000}
 .navy{color:#000060}
-.navy-background{background:#00007d}
+.navy-background{background-color:#00007d}
 .olive{color:#606000}
-.olive-background{background:#7d7d00}
+.olive-background{background-color:#7d7d00}
 .purple{color:#600060}
-.purple-background{background:#7d007d}
+.purple-background{background-color:#7d007d}
 .red{color:#bf0000}
-.red-background{background:#fa0000}
+.red-background{background-color:#fa0000}
 .silver{color:#909090}
-.silver-background{background:#bcbcbc}
+.silver-background{background-color:#bcbcbc}
 .teal{color:#006060}
-.teal-background{background:#007d7d}
+.teal-background{background-color:#007d7d}
 .white{color:#bfbfbf}
-.white-background{background:#fafafa}
+.white-background{background-color:#fafafa}
 .yellow{color:#bfbf00}
-.yellow-background{background:#fafa00}
+.yellow-background{background-color:#fafa00}
 span.icon>.fa{cursor:default}
 a span.icon>.fa{cursor:inherit}
 .admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.admonitionblock td.icon .icon-note:before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip:before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning:before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution:before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important:before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background-color:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
 .conum[data-value] *{color:#fff!important}
 .conum[data-value]+b{display:none}
-.conum[data-value]::after{content:attr(data-value)}
+.conum[data-value]:after{content:attr(data-value)}
 pre .conum[data-value]{position:relative;top:-.125em}
 b.conum *{color:inherit!important}
 .conum:not([data-value]):empty{display:none}
 dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
+h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
 p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,td.hdlist1,span.alt,summary{font-size:1.0625rem}
+p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
 p{margin-bottom:1.25rem}
 .sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.exampleblock>.content{background-color:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
 .print-only{display:none!important}
-@page{margin:1.25cm .75cm}
-@media print{*{box-shadow:none!important;text-shadow:none!important}
-html{font-size:80%}
+@media print{@page{margin:1.25cm .75cm}
+*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
 a{color:inherit!important;text-decoration:underline!important}
 a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]{border-bottom:1px dotted}
-abbr[title]::after{content:" (" attr(title) ")"}
+a[href^="http:"]:not(.bare):after,a[href^="https:"]:not(.bare):after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]:after{content:" (" attr(title) ")"}
 pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
 thead{display:table-header-group}
 svg{max-width:100%}
 p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
 h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#header,#content,#footnotes,#footer{max-width:none}
 #toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+#toc{border-bottom:1px solid #ddddd8!important;padding-bottom:0!important}
+.sect1{padding-bottom:0!important}
+.sect1+.sect1{border:0!important}
+#header>h1:first-child{margin-top:1.25rem}
 body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em 0}
 body.book #header .details{border:0!important;display:block;padding:0!important}
 body.book #header .details span:first-child{margin-left:0!important}
 body.book #header .details br{display:block}
-body.book #header .details br+span::before{content:none!important}
+body.book #header .details br+span:before{content:none!important}
 body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
 body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]::before{display:block}
-#footer{padding:0 .9375em}
+.listingblock code[data-lang]:before{display:block}
+#footer{background:none!important;padding:0 .9375em}
+#footer-text{color:rgba(0,0,0,.6)!important;font-size:.9em}
 .hide-on-print{display:none!important}
 .print-only{display:block!important}
 .hide-for-print{display:none!important}
 .show-for-print{display:inherit!important}}
-@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
-.sect1{padding:0!important}
-.sect1+.sect1{border:0}
-#footer{background:none}
-#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
-@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+
 </style>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 <style>
@@ -851,20 +843,21 @@ table.CodeRay td.code{padding:0 0 0 .75em}
 <ul class="sectlevel3">
 <li><a href="#_invoice_type_code_and_transaction_type">5.19.1. Invoice type code and transaction type</a></li>
 <li><a href="#_party_identification_8">5.19.2. Party identification</a></li>
-<li><a href="#_legal_registration_identifier">5.19.3. Legal registration identifier</a></li>
-<li><a href="#_country_subdivision_emirates">5.19.4. Country subdivision (Emirates)</a></li>
-<li><a href="#_currency_and_aed_amounts">5.19.5. Currency and AED amounts</a></li>
-<li><a href="#_item_type_classification_and_service_accounting_code">5.19.6. Item type, classification and Service Accounting Code</a></li>
-<li><a href="#_vat_category_rate_and_exemption">5.19.7. VAT category, rate and exemption</a></li>
-<li><a href="#_profit_margin_scheme">5.19.8. Profit Margin Scheme</a></li>
-<li><a href="#_reverse_charge_standard_item_identifier">5.19.9. Reverse charge: standard item identifier</a></li>
-<li><a href="#_free_trade_zone_beneficiary">5.19.10. Free Trade Zone Beneficiary</a></li>
-<li><a href="#_disclosed_agent_principle">5.19.11. Disclosed Agent Principle</a></li>
-<li><a href="#_deemed_supply">5.19.12. Deemed Supply</a></li>
-<li><a href="#_exports">5.19.13. Exports</a></li>
-<li><a href="#_credit_note_reason_code">5.19.14. Credit note reason code</a></li>
-<li><a href="#_out_of_scope_of_vat_and_credit_note_related_to_goods_or_services">5.19.15. Out of scope of VAT and Credit-note related to goods or services</a></li>
-<li><a href="#_self_billing_2">5.19.16. Self-billing</a></li>
+<li><a href="#_electronic_address_participant_identifier">5.19.3. Electronic address (Participant Identifier)</a></li>
+<li><a href="#_legal_registration_identifier">5.19.4. Legal registration identifier</a></li>
+<li><a href="#_country_subdivision_emirates">5.19.5. Country subdivision (Emirates)</a></li>
+<li><a href="#_currency_and_aed_amounts">5.19.6. Currency and AED amounts</a></li>
+<li><a href="#_item_type_classification_and_service_accounting_code">5.19.7. Item type, classification and Service Accounting Code</a></li>
+<li><a href="#_vat_category_rate_and_exemption">5.19.8. VAT category, rate and exemption</a></li>
+<li><a href="#_profit_margin_scheme">5.19.9. Profit Margin Scheme</a></li>
+<li><a href="#_reverse_charge_standard_item_identifier">5.19.10. Reverse charge: standard item identifier</a></li>
+<li><a href="#_free_trade_zone_beneficiary">5.19.11. Free Trade Zone Beneficiary</a></li>
+<li><a href="#_disclosed_agent_principle">5.19.12. Disclosed Agent Principle</a></li>
+<li><a href="#_deemed_supply">5.19.13. Deemed Supply</a></li>
+<li><a href="#_exports">5.19.14. Exports</a></li>
+<li><a href="#_credit_note_reason_code">5.19.15. Credit note reason code</a></li>
+<li><a href="#_out_of_scope_of_vat_and_credit_note_related_to_goods_or_services">5.19.16. Out of scope of VAT and Credit-note related to goods or services</a></li>
+<li><a href="#_self_billing_2">5.19.17. Self-billing</a></li>
 </ul>
 </li>
 <li><a href="#_united_states">5.20. United States</a>
@@ -17060,7 +17053,7 @@ Otherwise it is OK to omit the attribute.</td>
 <p>The UAE Tax Registration Number (TRN) is provided as the VAT identifier on <code>cac:PartyTaxScheme/cbc:CompanyID</code> with the tax scheme code <code>VAT</code>. The TRN is 15 alphanumeric characters, starts with <code>1</code> and ends with <code>03</code> (e.g. <code>100000000000003</code>).</p>
 </div>
 <div class="paragraph">
-<p>When the supplier is not VAT-registered, the Tax Identification Number (TIN) is provided instead under <code>cac:PartyIdentification/cbc:ID</code>. The TIN is 10 numeric digits starting with <code>1</code> (e.g. <code>1000000000</code>).</p>
+<p>When the supplier is not VAT-registered, the Tax Identification Number (TIN) is provided instead under <code>cac:PartyIdentification/cbc:ID</code> with <code>@schemeID = 'AE:TIN'</code>. The TIN is 10 numeric digits starting with <code>1</code> (e.g. <code>1000000000</code>) and, for a VAT-registered party, is the first 10 digits of the TRN.</p>
 </div>
 <div class="paragraph">
 <p><strong>Example</strong><br>
@@ -17095,7 +17088,68 @@ Otherwise it is OK to omit the attribute.</td>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_legal_registration_identifier"><a class="anchor" href="#_legal_registration_identifier"></a><a class="link" href="#_legal_registration_identifier">5.19.3. Legal registration identifier</a></h4>
+<h4 id="_electronic_address_participant_identifier"><a class="anchor" href="#_electronic_address_participant_identifier"></a><a class="link" href="#_electronic_address_participant_identifier">5.19.3. Electronic address (Participant Identifier)</a></h4>
+<div class="paragraph">
+<p>The seller and buyer electronic address (IBT-034 / IBT-049) is the Peppol <strong>Participant Identifier</strong> issued by the FTA. It MUST be the <strong>10-digit TIN</strong> under the Peppol EAS scheme <code>0235</code>.</p>
+</div>
+<div class="paragraph">
+<p>The TIN is the first 10 digits of the 15-character TRN. The full TRN MUST NOT be used as the electronic address — it belongs on <code>cac:PartyTaxScheme/cbc:CompanyID</code> (IBT-031 / IBT-048) only.</p>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-important" title="Important"></i>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>The PUF-008 scheme code <code>AE:TIN</code> applies to <code>cac:PartyIdentification/cbc:ID</code>. It is <strong>not</strong> an endpoint scheme — <code>cbc:EndpointID/@schemeID</code> always carries the Peppol EAS code <code>0235</code>.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><strong>Example</strong><br>
+<em>Seller with TRN <code>100000000000003</code> and the derived Participant Identifier</em></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
+  <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+  <span class="tag">&lt;cac:AccountingSupplierParty&gt;</span>
+    <span class="tag">&lt;cac:Party&gt;</span>
+      <span class="tag">&lt;cbc:EndpointID</span> <span class="attribute-name">schemeID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">0235</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>1000000000<span class="tag">&lt;/cbc:EndpointID&gt;</span><i class="conum" data-value="1"></i><b>(1)</b>
+      <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+      <span class="tag">&lt;cac:PartyTaxScheme&gt;</span>
+        <span class="tag">&lt;cbc:CompanyID&gt;</span>100000000000003<span class="tag">&lt;/cbc:CompanyID&gt;</span><i class="conum" data-value="2"></i><b>(2)</b>
+        <span class="tag">&lt;cac:TaxScheme&gt;</span>
+          <span class="tag">&lt;cbc:ID&gt;</span>VAT<span class="tag">&lt;/cbc:ID&gt;</span>
+        <span class="tag">&lt;/cac:TaxScheme&gt;</span>
+      <span class="tag">&lt;/cac:PartyTaxScheme&gt;</span>
+    <span class="tag">&lt;/cac:Party&gt;</span>
+  <span class="tag">&lt;/cac:AccountingSupplierParty&gt;</span>
+<span class="tag">&lt;/Invoice&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Participant Identifier: scheme <code>0235</code> with the 10-digit TIN (the first 10 digits of the TRN).</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>The full 15-character TRN stays on <code>cac:PartyTaxScheme/cbc:CompanyID</code>.</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>A party that is within scope of UAE e-invoicing but not registered for VAT has no TRN. It still has a TIN, obtained by registering with the FTA, and uses that TIN as its Participant Identifier.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_legal_registration_identifier"><a class="anchor" href="#_legal_registration_identifier"></a><a class="link" href="#_legal_registration_identifier">5.19.4. Legal registration identifier</a></h4>
 <div class="paragraph">
 <p>UAE requires a legal registration identifier on both seller and buyer. PUF carries this through <code>cac:PartyLegalEntity/cbc:CompanyID</code> with the registration type expressed via the standard <code>@schemeID</code> attribute. PUF does not use the PINT-AE <code>@schemeAgencyID</code> / <code>@schemeAgencyName</code> syntax — every UAE identifier flavour has its own PUF-008 scheme code.</p>
 </div>
@@ -17174,7 +17228,7 @@ Otherwise it is OK to omit the attribute.</td>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_country_subdivision_emirates"><a class="anchor" href="#_country_subdivision_emirates"></a><a class="link" href="#_country_subdivision_emirates">5.19.4. Country subdivision (Emirates)</a></h4>
+<h4 id="_country_subdivision_emirates"><a class="anchor" href="#_country_subdivision_emirates"></a><a class="link" href="#_country_subdivision_emirates">5.19.5. Country subdivision (Emirates)</a></h4>
 <div class="paragraph">
 <p>Whenever a UAE address is provided (seller, buyer, delivery, tax representative), the country subdivision MUST be one of the seven Emirate codes:</p>
 </div>
@@ -17225,7 +17279,7 @@ Otherwise it is OK to omit the attribute.</td>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_currency_and_aed_amounts"><a class="anchor" href="#_currency_and_aed_amounts"></a><a class="link" href="#_currency_and_aed_amounts">5.19.5. Currency and AED amounts</a></h4>
+<h4 id="_currency_and_aed_amounts"><a class="anchor" href="#_currency_and_aed_amounts"></a><a class="link" href="#_currency_and_aed_amounts">5.19.6. Currency and AED amounts</a></h4>
 <div class="paragraph">
 <p>The document currency code MUST be present (<code>cbc:DocumentCurrencyCode</code>). If the document currency is not AED, the tax accounting currency MUST be set to <code>AED</code> (<code>cbc:TaxCurrencyCode = 'AED'</code>) and the currency exchange rate MUST be provided.</p>
 </div>
@@ -17270,7 +17324,7 @@ Otherwise it is OK to omit the attribute.</td>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_item_type_classification_and_service_accounting_code"><a class="anchor" href="#_item_type_classification_and_service_accounting_code"></a><a class="link" href="#_item_type_classification_and_service_accounting_code">5.19.6. Item type, classification and Service Accounting Code</a></h4>
+<h4 id="_item_type_classification_and_service_accounting_code"><a class="anchor" href="#_item_type_classification_and_service_accounting_code"></a><a class="link" href="#_item_type_classification_and_service_accounting_code">5.19.7. Item type, classification and Service Accounting Code</a></h4>
 <div class="paragraph">
 <p>Every UAE invoice line MUST declare whether the item is goods, a service, or both, via the <strong>item type</strong> (BTAE-13). It is provided through <code>cac:CommodityClassification/cbc:CommodityCode</code>:</p>
 </div>
@@ -17320,14 +17374,14 @@ Otherwise it is OK to omit the attribute.</td>
 <i class="fa icon-note" title="Note"></i>
 </td>
 <td class="content">
-Per the PINT-AE syntax, <code>cbc:ItemClassificationCode</code> (scheme <code>HS</code>) is mandatory (1..1) within every <code>cac:CommodityClassification</code>. A line that carries <code>cbc:CommodityCode</code> therefore also carries an <code>cbc:ItemClassificationCode</code>. A service line additionally provides the Service Accounting Code (BTAE-17) in <code>cac:AdditionalItemIdentification</code>.
+The PINT-AE syntax table shows <code>cbc:ItemClassificationCode</code> as 1..1 within <code>cac:CommodityClassification</code>, but the validation artefacts do not enforce this: <code>ibr-184-ae</code> requires the item classification only when the item type is <code>G</code> (or <code>B</code>), and <code>ibr-188-ae</code> constrains the scheme identifier only when a classification is actually present. A pure service line therefore carries <code>cbc:CommodityCode</code> alone and is classified by its Service Accounting Code (BTAE-17). Do not invent an HS code for a service — HS classifies goods, and a placeholder value would misreport the supply.
 </td>
 </tr>
 </table>
 </div>
 <div class="paragraph">
 <p><strong>Example</strong><br>
-<em>Line for a service, carrying the item type, the item classification and the SAC code</em></p>
+<em>Line for a service, carrying the item type and the SAC code</em></p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -17341,7 +17395,6 @@ Per the PINT-AE syntax, <code>cbc:ItemClassificationCode</code> (scheme <code>HS
     <span class="tag">&lt;/cac:AdditionalItemIdentification&gt;</span>
     <span class="tag">&lt;cac:CommodityClassification&gt;</span>
       <span class="tag">&lt;cbc:CommodityCode&gt;</span>S<span class="tag">&lt;/cbc:CommodityCode&gt;</span><i class="conum" data-value="2"></i><b>(2)</b>
-      <span class="tag">&lt;cbc:ItemClassificationCode</span> <span class="attribute-name">listID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">HS</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>8523.49.00<span class="tag">&lt;/cbc:ItemClassificationCode&gt;</span><i class="conum" data-value="3"></i><b>(3)</b>
     <span class="tag">&lt;/cac:CommodityClassification&gt;</span>
   <span class="tag">&lt;/cac:Item&gt;</span>
 <span class="tag">&lt;/cac:InvoiceLine&gt;</span></code></pre>
@@ -17355,17 +17408,13 @@ Per the PINT-AE syntax, <code>cbc:ItemClassificationCode</code> (scheme <code>HS
 </tr>
 <tr>
 <td><i class="conum" data-value="2"></i><b>2</b></td>
-<td>Item type <code>S</code> (Services) via <code>cac:CommodityClassification/cbc:CommodityCode</code>.</td>
-</tr>
-<tr>
-<td><i class="conum" data-value="3"></i><b>3</b></td>
-<td>Item classification identifier, mandatory (1..1) within the <code>cac:CommodityClassification</code>; scheme <code>HS</code> (ibr-188-ae).</td>
+<td>Item type <code>S</code> (Services) via <code>cac:CommodityClassification/cbc:CommodityCode</code>. No <code>cbc:ItemClassificationCode</code> — services are not classified by HS.</td>
 </tr>
 </table>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_vat_category_rate_and_exemption"><a class="anchor" href="#_vat_category_rate_and_exemption"></a><a class="link" href="#_vat_category_rate_and_exemption">5.19.7. VAT category, rate and exemption</a></h4>
+<h4 id="_vat_category_rate_and_exemption"><a class="anchor" href="#_vat_category_rate_and_exemption"></a><a class="link" href="#_vat_category_rate_and_exemption">5.19.8. VAT category, rate and exemption</a></h4>
 <div class="paragraph">
 <p>UAE uses the EN/Peppol VAT category code set: <code>S</code> (Standard rated), <code>Z</code> (Zero rated), <code>E</code> (Exempt from VAT), <code>O</code> (Not subject to VAT), <code>AE</code> (Reverse charge) and <code>N</code> (Standard rate additional VAT).</p>
 </div>
@@ -17384,7 +17433,7 @@ Per the PINT-AE syntax, <code>cbc:ItemClassificationCode</code> (scheme <code>HS
 </div>
 </div>
 <div class="sect3">
-<h4 id="_profit_margin_scheme"><a class="anchor" href="#_profit_margin_scheme"></a><a class="link" href="#_profit_margin_scheme">5.19.8. Profit Margin Scheme</a></h4>
+<h4 id="_profit_margin_scheme"><a class="anchor" href="#_profit_margin_scheme"></a><a class="link" href="#_profit_margin_scheme">5.19.9. Profit Margin Scheme</a></h4>
 <div class="paragraph">
 <p>Supplies under the UAE VAT Profit Margin Scheme (Article 43 of the UAE VAT Decree-Law) use VAT category code <code>N</code> (<em>Standard rate additional VAT</em> — standard VAT calculated for an additional taxable base when the additional taxable base is not included in the document totals). Under the scheme, VAT is assessed on the supplier&#8217;s profit margin and settled directly with the FTA; it is not charged to the buyer and the VAT <strong>amount</strong> on the invoice is always zero. The statutory rate (<code>5.00</code>) MUST nevertheless be provided in the <code>cbc:Percent</code> field.</p>
 </div>
@@ -17436,13 +17485,13 @@ Per the PINT-AE syntax, <code>cbc:ItemClassificationCode</code> (scheme <code>HS
 </div>
 </div>
 <div class="sect3">
-<h4 id="_reverse_charge_standard_item_identifier"><a class="anchor" href="#_reverse_charge_standard_item_identifier"></a><a class="link" href="#_reverse_charge_standard_item_identifier">5.19.9. Reverse charge: standard item identifier</a></h4>
+<h4 id="_reverse_charge_standard_item_identifier"><a class="anchor" href="#_reverse_charge_standard_item_identifier"></a><a class="link" href="#_reverse_charge_standard_item_identifier">5.19.10. Reverse charge: standard item identifier</a></h4>
 <div class="paragraph">
 <p>When the line is reverse-charged (category <code>AE</code>), the line MUST carry an <strong>item standard identifier</strong> (<code>cac:StandardItemIdentification/cbc:ID</code>) with <code>@schemeID = "0160"</code> (GS1 GTIN).</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_free_trade_zone_beneficiary"><a class="anchor" href="#_free_trade_zone_beneficiary"></a><a class="link" href="#_free_trade_zone_beneficiary">5.19.10. Free Trade Zone Beneficiary</a></h4>
+<h4 id="_free_trade_zone_beneficiary"><a class="anchor" href="#_free_trade_zone_beneficiary"></a><a class="link" href="#_free_trade_zone_beneficiary">5.19.11. Free Trade Zone Beneficiary</a></h4>
 <div class="paragraph">
 <p>In free-trade-zone supplies (BTAE-02 transaction type code matching the FTZ flag, <code>1XXXXXXX</code>), the <strong>Beneficiary ID</strong> (BTAE-01) — the TRN or TIN of the FTZ beneficiary — is carried using the existing <code>puf:RestrictedInformationParty</code> extension with <code>Key = 'Beneficiary'</code>.</p>
 </div>
@@ -17487,13 +17536,13 @@ Per the PINT-AE syntax, <code>cbc:ItemClassificationCode</code> (scheme <code>HS
 </div>
 </div>
 <div class="sect3">
-<h4 id="_disclosed_agent_principle"><a class="anchor" href="#_disclosed_agent_principle"></a><a class="link" href="#_disclosed_agent_principle">5.19.11. Disclosed Agent Principle</a></h4>
+<h4 id="_disclosed_agent_principle"><a class="anchor" href="#_disclosed_agent_principle"></a><a class="link" href="#_disclosed_agent_principle">5.19.12. Disclosed Agent Principle</a></h4>
 <div class="paragraph">
 <p>In disclosed-agent billing (BTAE-02 transaction type code matching the disclosed-agent flag, <code>XXXXX1XX</code>), the <strong>Principle ID</strong> (BTAE-14) — the TRN of the principle — is carried using the same <code>puf:RestrictedInformationParty</code> extension with <code>Key = 'Principle'</code>. The Principle ID MUST be different from the Seller VAT identifier.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_deemed_supply"><a class="anchor" href="#_deemed_supply"></a><a class="link" href="#_deemed_supply">5.19.12. Deemed Supply</a></h4>
+<h4 id="_deemed_supply"><a class="anchor" href="#_deemed_supply"></a><a class="link" href="#_deemed_supply">5.19.13. Deemed Supply</a></h4>
 <div class="paragraph">
 <p>Deemed supplies (BTAE-02 position 2 set to <code>1</code>, e.g. <code>01000000</code>) are supplies made without consideration — typically gifts or samples above the FTA de-minimis threshold. Because no buyer exists, PUF uses a set of fixed FTA placeholder values:</p>
 </div>
@@ -17515,7 +17564,7 @@ Per the PINT-AE syntax, <code>cbc:ItemClassificationCode</code> (scheme <code>HS
 </div>
 </div>
 <div class="sect3">
-<h4 id="_exports"><a class="anchor" href="#_exports"></a><a class="link" href="#_exports">5.19.13. Exports</a></h4>
+<h4 id="_exports"><a class="anchor" href="#_exports"></a><a class="link" href="#_exports">5.19.14. Exports</a></h4>
 <div class="paragraph">
 <p>Export supplies (BTAE-02 position 8 set to <code>1</code>, e.g. <code>00000001</code>) are zero-rated supplies of goods or services delivered outside the UAE. Delivery information is mandatory.</p>
 </div>
@@ -17540,7 +17589,7 @@ Per the PINT-AE syntax, <code>cbc:ItemClassificationCode</code> (scheme <code>HS
 </div>
 </div>
 <div class="sect3">
-<h4 id="_credit_note_reason_code"><a class="anchor" href="#_credit_note_reason_code"></a><a class="link" href="#_credit_note_reason_code">5.19.14. Credit note reason code</a></h4>
+<h4 id="_credit_note_reason_code"><a class="anchor" href="#_credit_note_reason_code"></a><a class="link" href="#_credit_note_reason_code">5.19.15. Credit note reason code</a></h4>
 <div class="paragraph">
 <p>When the document is a credit note (<code>cbc:InvoiceTypeCode = 381</code> or <code>cbc:CreditNoteTypeCode = 81</code>), the credit note reason code (BTAE-03) MUST be provided. Supported values are:</p>
 </div>
@@ -17587,13 +17636,13 @@ Per the PINT-AE syntax, <code>cbc:ItemClassificationCode</code> (scheme <code>HS
 </div>
 </div>
 <div class="sect3">
-<h4 id="_out_of_scope_of_vat_and_credit_note_related_to_goods_or_services"><a class="anchor" href="#_out_of_scope_of_vat_and_credit_note_related_to_goods_or_services"></a><a class="link" href="#_out_of_scope_of_vat_and_credit_note_related_to_goods_or_services">5.19.15. Out of scope of VAT and Credit-note related to goods or services</a></h4>
+<h4 id="_out_of_scope_of_vat_and_credit_note_related_to_goods_or_services"><a class="anchor" href="#_out_of_scope_of_vat_and_credit_note_related_to_goods_or_services"></a><a class="link" href="#_out_of_scope_of_vat_and_credit_note_related_to_goods_or_services">5.19.16. Out of scope of VAT and Credit-note related to goods or services</a></h4>
 <div class="paragraph">
 <p>When the invoice type code is <code>480</code> (Out of scope of VAT) or <code>81</code> (Credit note related to goods or services), the buyer&#8217;s legal registration identifier (IBT-047) is mandatory regardless of whether the buyer is VAT-registered, and all VAT category codes used on the document MUST be one of <code>E</code> / <code>O</code> / <code>Z</code>. The seller VAT identifier is <strong>not</strong> required in these cases.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_self_billing_2"><a class="anchor" href="#_self_billing_2"></a><a class="link" href="#_self_billing_2">5.19.16. Self-billing</a></h4>
+<h4 id="_self_billing_2"><a class="anchor" href="#_self_billing_2"></a><a class="link" href="#_self_billing_2">5.19.17. Self-billing</a></h4>
 <div class="paragraph">
 <p>In PUF, self-billing is <strong>not</strong> signalled through a dedicated UBL document type code. Self-billed documents keep their original type code (<code>cbc:InvoiceTypeCode = 380</code> for a self-billed tax invoice, <code>cbc:CreditNoteTypeCode = 381</code> for a self-billed credit note) and are flagged through the standard <code>puf:SelfBilled</code> extension at document level. See <code><a href="#_selfbilled">Self-Billed extension</a></code> for the structure.</p>
 </div>

--- a/index.html
+++ b/index.html
@@ -4,27 +4,25 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.23">
+<meta name="generator" content="Asciidoctor 2.0.26">
 <meta name="author" content="Copyright &copy; 2025, Pagero, Part of Thomson Reuters">
 <meta name="copyright" content="Pagero, Part of Thomson Reuters">
 <title>PUF Billing 2.0</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
-@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
-article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
-audio,canvas,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-[hidden],template{display:none}
-script{display:none!important}
-html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
-a{background:transparent}
+/*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment the following line when using as a custom stylesheet */
+/* @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"; */
+html{font-family:sans-serif;-webkit-text-size-adjust:100%}
+a{background:none}
 a:focus{outline:thin dotted}
 a:active,a:hover{outline:0}
 h1{font-size:2em;margin:.67em 0}
-abbr[title]{border-bottom:1px dotted}
 b,strong{font-weight:bold}
+abbr{font-size:.9em}
+abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
 dfn{font-style:italic}
-hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
+hr{height:0}
 mark{background:#ff0;color:#000}
 code,kbd,pre,samp{font-family:monospace;font-size:1em}
 pre{white-space:pre-wrap}
@@ -36,22 +34,22 @@ sub{bottom:-.25em}
 img{border:0}
 svg:not(:root){overflow:hidden}
 figure{margin:0}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
 fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
 legend{border:0;padding:0}
 button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
 button,input{line-height:normal}
 button,select{text-transform:none}
-button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
+button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
 button[disabled],html input[disabled]{cursor:default}
-input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
-input[type="search"]{-webkit-appearance:textfield;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;box-sizing:content-box}
-input[type="search"]::-webkit-search-cancel-button,input[type="search"]::-webkit-search-decoration{-webkit-appearance:none}
+input[type=checkbox],input[type=radio]{padding:0}
 button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
 textarea{overflow:auto;vertical-align:top}
 table{border-collapse:collapse;border-spacing:0}
-*,*:before,*:after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
-html,body{font-size:95%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+*,::before,::after{box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
 a:hover{cursor:pointer}
 img,object,embed{max-width:100%;height:auto}
 object,embed{height:100%}
@@ -66,69 +64,65 @@ img{-ms-interpolation-mode:bicubic}
 img,object,svg{display:inline-block;vertical-align:middle}
 textarea{height:auto;min-height:50px}
 select{width:100%}
-.center{margin-left:auto;margin-right:auto}
-.spread{width:100%}
-.stretch{width:100%}
-p.lead,.paragraph.lead>p,#preamble>.sectionbody>.paragraph:first-of-type p{font-size:1.21875em;line-height:1.6}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#0d603d;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr;border-bottom: ;}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
 a{color:#2156a5;text-decoration:underline;line-height:inherit}
 a:hover,a:focus{color:#1d4b8f}
-a img{border:none}
-p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+a img{border:0}
+p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
 p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#0d603d;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#0d603d;line-height:0}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
 h1{font-size:2.125em}
-h2{font-size:1.6875em;}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em;border-top:1px solid #ddddd8}
-h4,h5{font-size:1.125em;border-top:1px solid #ddddd8}
-h6{font-size:1em;border-top:1px solid #ddddd8}
-hr{border:solid #ddddd8;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
 em,i{font-style:italic;line-height:inherit}
 strong,b{font-weight:bold;line-height:inherit}
 small{font-size:60%;line-height:inherit}
 code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
 ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
 ul.circle{list-style-type:circle}
 ul.disc{list-style-type:disc}
+ul.square{list-style-type:square}
+ul.circle ul:not([class]),ul.disc ul:not([class]),ul.square ul:not([class]){list-style:inherit}
 ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
 dl dt{margin-bottom:.3125em;font-weight:bold}
 dl dd{margin-bottom:1.25em}
-abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
-abbr{text-transform:none}
 blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
-blockquote cite:before{content:"\2014 \0020"}
-blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
 blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media only screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
 h1{font-size:2.75em}
 h2{font-size:2.3125em}
 h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
 h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
-table thead,table tfoot{background:#f7f8f7;font-weight:bold}
+table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
+table thead,table tfoot{background:#f7f8f7}
 table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
 table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt,table tr:nth-of-type(even){background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em; padding: 2rem 0 1rem 0;}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
 h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.clearfix:before,.clearfix:after,.float-group:before,.float-group:after{content:" ";display:table}
-.clearfix:after,.float-group:after{clear:both}
-*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
-*:not(pre)>code.nobreak{word-wrap:normal}
-*:not(pre)>code.nowrap{white-space:nowrap}
-pre,pre>code{line-height:1.45;color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;text-rendering:optimizeSpeed}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre).nobreak{word-wrap:normal}
+:not(pre).nowrap{white-space:nowrap}
+:not(pre).pre-wrap{white-space:pre-wrap}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
 em em{font-style:normal}
 strong strong{font-weight:400}
 .keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background-color:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
 .keyseq kbd:first-child{margin-left:0}
 .keyseq kbd:last-child{margin-right:0}
 .menuseq,.menuref{color:#000}
@@ -136,139 +130,151 @@ kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-bl
 .menuseq{word-spacing:-.02em}
 .menuseq b.caret{font-size:1.25em;line-height:.8}
 .menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
-b.button:before,b.button:after{position:relative;top:-1px;font-weight:400}
-b.button:before{content:"[";padding:0 3px 0 2px}
-b.button:after{content:"]";padding:0 2px 0 3px}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
 p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header:before,#header:after,#content:before,#content:after,#footnotes:before,#footnotes:after,#footer:before,#footer:after{content:" ";display:table}
-#header:after,#content:after,#footnotes:after,#footer:after{clear:both}
+#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
 #content{margin-top:1.25em}
-#content:before{content:none}
+#content::before{content:none}
 #header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #ddddd8}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #ddddd8;padding-bottom:8px}
-details>summary:first-of-type{cursor:pointer;display:list-item;outline:none;margin-bottom:.75em}
-#header .details{border-bottom:1px solid #ddddd8;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child{border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
 #header .details span:first-child{margin-left:-.125em}
 #header .details span.email a{color:rgba(0,0,0,.85)}
 #header .details br{display:none}
-#header .details br+span:before{content:"\00a0\2013\00a0"}
-#header .details br+span.author:before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark:before{content:"\00a0|\00a0"}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
 #header #revnumber{text-transform:capitalize}
-#header #revnumber:after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #ddddd8;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{background-color:#183c34;border-bottom:1px solid #efefed;padding-bottom:.5em}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
 #toc>ul{margin-left:.125em}
 #toc ul.sectlevel0>li>a{font-style:italic}
 #toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
 #toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
 #toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none;color:#dddddd}
+#toc a{text-decoration:none}
 #toc a:active{text-decoration:underline}
-#toctitle{color:#dddddd;font-size:1.2em;border-top:none!important;padding:0;}
-@media only screen and (min-width:768px){#toctitle{font-size:1.375em}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
 body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background-color:#183c34;position:fixed;width:15em;left:0;top:0;border-right:1px solid #efefed;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
 #toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0;}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
 #toc.toc2 ul ul{margin-left:0;padding-left:1em}
 #toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
 body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #efefed;left:auto;right:0}}
-@media only screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:auto}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
 #toc.toc2 #toctitle{font-size:1.375em}
 #toc.toc2>ul{font-size:.95em}
 #toc.toc2 ul ul{padding-left:1.25em}
 body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
 #content #toc>:first-child{margin-top:0}
 #content #toc>:last-child{margin-bottom:0}
-#footer{max-width:100%;background-color:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
+#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
+#content{margin-bottom:.625em}
 .sect1{padding-bottom:.625em}
-@media only screen and (min-width:768px){.sect1{padding-bottom:1.25em}}
-.sect1+.sect1{border-top:1px solid #efefed}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
 #content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor:before,h2>a.anchor:before,h3>a.anchor:before,#toctitle>a.anchor:before,.sidebarblock>.content>.title>a.anchor:before,h4>a.anchor:before,h5>a.anchor:before,h6>a.anchor:before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em;color: #0d603d}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
 #content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#0d603d;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#0d603d}
-.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details{margin-left:1.25rem}
+details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
+details>summary::-webkit-details-marker{display:none}
+details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
+details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
+details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
 .admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock>caption.title{white-space:nowrap;overflow:visible;max-width:0}
-.paragraph.lead>p,#preamble>.sectionbody>.paragraph:first-of-type p{color:rgba(0,0,0,.85)}
-table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p{font-size:inherit}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
 .admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
 .admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:initial}
+.admonitionblock>table td.icon img{max-width:none}
 .admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #ddddd8;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
 .admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
+.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
+.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
 .sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock pre:not(.highlight),.listingblock pre[class="highlight"],.listingblock pre[class^="highlight "],.listingblock pre.CodeRay,.listingblock pre.prettyprint{background:#f7f7f8}
-.sidebarblock .literalblock pre,.sidebarblock .listingblock pre:not(.highlight),.sidebarblock .listingblock pre[class="highlight"],.sidebarblock .listingblock pre[class^="highlight "],.sidebarblock .listingblock pre.CodeRay,.sidebarblock .listingblock pre.prettyprint{background:#f2f1f1}
-.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;padding:1em;font-size:.8125em}
-.literalblock pre.nowrap,.literalblock pre[class].nowrap,.listingblock pre.nowrap,.listingblock pre[class].nowrap{overflow-x:auto;white-space:pre;word-wrap:normal}
-@media only screen and (min-width:768px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:.90625em}}
-@media only screen and (min-width:1280px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:1em}}
-.literalblock.output pre{color:#f7f7f8;background-color:rgba(0,0,0,.9)}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
+.exampleblock>.content>:first-child,.sidebarblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child,.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
 .listingblock>.content{position:relative}
-.listingblock code[data-lang]:before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:#999}
-.listingblock:hover code[data-lang]:before{display:block}
-.listingblock.terminal pre .command:before{content:attr(data-prompt);padding-right:.5em;color:#999}
-.listingblock.terminal pre .command:not([data-prompt]):before{content:"$"}
-table.pyhltable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.pyhltable td{vertical-align:top;padding-top:0;padding-bottom:0;line-height:1.45}
-table.pyhltable td.code{padding-left:.75em;padding-right:0}
-pre.pygments .lineno,table.pyhltable td:not(.code){color:#999;padding-left:0;padding-right:.5em;border-right:1px solid #ddddd8}
-pre.pygments .lineno{display:inline-block;margin-right:.25em}
-table.pyhltable .linenodiv{background:none!important;padding-right:0!important}
+.listingblock pre>code{display:block}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
+pre.pygments span.linenos{display:inline-block;margin-right:.75em}
 .quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock blockquote p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
 .quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote:before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
 .quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.5em;margin-right:.5ex;text-align:right}
-.quoteblock .quoteblock{margin-left:0;margin-right:0;padding:.5em 0;border-left:3px solid rgba(0,0,0,.6)}
-.quoteblock .quoteblock blockquote{padding:0 0 0 .75em}
-.quoteblock .quoteblock blockquote:before{display:none}
-.verseblock{margin:0 1em 1.25em 1em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
 .verseblock pre strong{font-weight:400}
 .verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
 .quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
 .quoteblock .attribution br,.verseblock .attribution br{display:none}
 .quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract{margin:0 0 1.25em 0;display:block}
-.quoteblock.abstract blockquote,.quoteblock.abstract blockquote p{text-align:left;word-spacing:0}
-.quoteblock.abstract blockquote:before,.quoteblock.abstract blockquote p:first-of-type:before{display:none}
-table.tableblock{max-width:100%;border-collapse:separate}
-table.tableblock td>.paragraph:last-child p>p:last-child,table.tableblock th>p:last-child,table.tableblock td>p:last-child{margin-bottom:0}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
 table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
-table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
-table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
-table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px 0}
-table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0 0}
-table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
-table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
+table.grid-all>*>tr>*{border-width:1px}
+table.grid-cols>*>tr>*{border-width:0 1px}
+table.grid-rows>*>tr>*{border-width:1px 0}
 table.frame-all{border-width:1px}
+table.frame-ends{border-width:1px 0}
 table.frame-sides{border-width:0 1px}
-table.frame-topbot{border-width:1px 0}
+table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
+table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
+table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
+table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
+table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
 th.halign-left,td.halign-left{text-align:left}
 th.halign-right,td.halign-right{text-align:right}
 th.halign-center,td.halign-center{text-align:center}
@@ -276,25 +282,24 @@ th.valign-top,td.valign-top{vertical-align:top}
 th.valign-bottom,td.valign-bottom{vertical-align:bottom}
 th.valign-middle,td.valign-middle{vertical-align:middle}
 table thead th,table tfoot th{font-weight:bold}
-tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
+tbody tr th{background:#f7f8f7}
 tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
 p.tableblock>code:only-child{background:none;padding:0}
 p.tableblock{font-size:1em}
-td>div.verse{white-space:pre}
 ol{margin-left:1.75em}
 ul li ol{margin-left:1.5em}
 dl dd{margin-left:1.125em}
 dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
 ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
 ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
 ul.unstyled,ol.unstyled{margin-left:0}
-ul.checklist{margin-left:.625em}
-ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
-ul.inline{margin:0 auto .625em auto;margin-left:-1.375em;margin-right:0;padding:0;list-style:none;overflow:hidden}
-ul.inline>li{list-style:none;float:left;margin-left:1.375em;display:block}
-ul.inline>li>*{display:block}
+li>p:empty:only-child::before{content:"";display:inline-block}
+ul.checklist>li>p:first-child{margin-left:-1em}
+ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
+ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
 .unstyled dl dt{font-weight:400;font-style:normal}
 ol.arabic{list-style-type:decimal}
 ol.decimal{list-style-type:decimal-leading-zero}
@@ -307,13 +312,14 @@ ol.lowergreek{list-style-type:lower-greek}
 .hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
 td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
 td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+td.hdlist2{word-wrap:anywhere}
 .literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist>table tr>td:first-of-type{padding:.4em .75em 0 .75em;line-height:1;vertical-align:top}
-.colist>table tr>td:first-of-type img{max-width:initial}
-.colist>table tr>td:last-of-type{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
-.imageblock.left,.imageblock[style*="float: left"]{margin:.25em .625em 1.25em 0}
-.imageblock.right,.imageblock[style*="float: right"]{margin:.25em 0 1.25em .625em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
 .imageblock>.title{margin-bottom:0}
 .imageblock.thumb,.imageblock.th{border-width:6px}
 .imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
@@ -324,15 +330,13 @@ a.image{text-decoration:none;display:inline-block}
 a.image object{pointer-events:none}
 sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
 sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+sup.footnote a:active,sup.footnoteref a:active,#footnotes .footnote a:first-of-type:active{text-decoration:underline}
 #footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em 0;border-width:1px 0 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;text-indent:-1.05em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
 #footnotes .footnote:last-of-type{margin-bottom:0}
 #content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
-.gist .file-data>table td.line-data{width:99%}
 div.unbreakable{page-break-inside:avoid}
 .big{font-size:larger}
 .small{font-size:smaller}
@@ -340,92 +344,96 @@ div.unbreakable{page-break-inside:avoid}
 .overline{text-decoration:overline}
 .line-through{text-decoration:line-through}
 .aqua{color:#00bfbf}
-.aqua-background{background-color:#00fafa}
+.aqua-background{background:#00fafa}
 .black{color:#000}
-.black-background{background-color:#000}
+.black-background{background:#000}
 .blue{color:#0000bf}
-.blue-background{background-color:#0000fa}
+.blue-background{background:#0000fa}
 .fuchsia{color:#bf00bf}
-.fuchsia-background{background-color:#fa00fa}
+.fuchsia-background{background:#fa00fa}
 .gray{color:#606060}
-.gray-background{background-color:#7d7d7d}
+.gray-background{background:#7d7d7d}
 .green{color:#006000}
-.green-background{background-color:#007d00}
+.green-background{background:#007d00}
 .lime{color:#00bf00}
-.lime-background{background-color:#00fa00}
+.lime-background{background:#00fa00}
 .maroon{color:#600000}
-.maroon-background{background-color:#7d0000}
+.maroon-background{background:#7d0000}
 .navy{color:#000060}
-.navy-background{background-color:#00007d}
+.navy-background{background:#00007d}
 .olive{color:#606000}
-.olive-background{background-color:#7d7d00}
+.olive-background{background:#7d7d00}
 .purple{color:#600060}
-.purple-background{background-color:#7d007d}
+.purple-background{background:#7d007d}
 .red{color:#bf0000}
-.red-background{background-color:#fa0000}
+.red-background{background:#fa0000}
 .silver{color:#909090}
-.silver-background{background-color:#bcbcbc}
+.silver-background{background:#bcbcbc}
 .teal{color:#006060}
-.teal-background{background-color:#007d7d}
+.teal-background{background:#007d7d}
 .white{color:#bfbfbf}
-.white-background{background-color:#fafafa}
+.white-background{background:#fafafa}
 .yellow{color:#bfbf00}
-.yellow-background{background-color:#fafa00}
+.yellow-background{background:#fafa00}
 span.icon>.fa{cursor:default}
 a span.icon>.fa{cursor:inherit}
 .admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note:before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip:before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning:before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution:before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important:before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background-color:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
 .conum[data-value] *{color:#fff!important}
 .conum[data-value]+b{display:none}
-.conum[data-value]:after{content:attr(data-value)}
+.conum[data-value]::after{content:attr(data-value)}
 pre .conum[data-value]{position:relative;top:-.125em}
 b.conum *{color:inherit!important}
 .conum:not([data-value]):empty{display:none}
 dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
+h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
 p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
+p,blockquote,dt,td.content,td.hdlist1,span.alt,summary{font-size:1.0625rem}
 p{margin-bottom:1.25rem}
 .sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background-color:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
 .print-only{display:none!important}
-@media print{@page{margin:1.25cm .75cm}
-*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
 a{color:inherit!important;text-decoration:underline!important}
 a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare):after,a[href^="https:"]:not(.bare):after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]:after{content:" (" attr(title) ")"}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]{border-bottom:1px dotted}
+abbr[title]::after{content:" (" attr(title) ")"}
 pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
 thead{display:table-header-group}
 svg{max-width:100%}
 p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
 h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#header,#content,#footnotes,#footer{max-width:none}
 #toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #ddddd8!important;padding-bottom:0!important}
-.sect1{padding-bottom:0!important}
-.sect1+.sect1{border:0!important}
-#header>h1:first-child{margin-top:1.25rem}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
 body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em 0}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
 body.book #header .details{border:0!important;display:block;padding:0!important}
 body.book #header .details span:first-child{margin-left:0!important}
 body.book #header .details br{display:block}
-body.book #header .details br+span:before{content:none!important}
+body.book #header .details br+span::before{content:none!important}
 body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
 body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]:before{display:block}
-#footer{background:none!important;padding:0 .9375em}
-#footer-text{color:rgba(0,0,0,.6)!important;font-size:.9em}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
 .hide-on-print{display:none!important}
 .print-only{display:block!important}
 .hide-for-print{display:none!important}
 .show-for-print{display:inherit!important}}
-
+@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
 </style>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 <style>
@@ -6140,6 +6148,11 @@ Country code from where the item origin.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:CommodityClassification/cbc:NatureCode</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Commodity Classification. Nature Code.</strong><br>
 A code defined by a specific maintenance agency signifying the high-level nature of the commodity.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:CommodityClassification/cbc:CommodityCode</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Commodity Classification. Commodity Code.</strong><br>
+The type of commodity. Used by some jurisdictions to indicate whether the item is goods, a service, or both — see country specifics.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:CommodityClassification/cbc:ItemClassificationCode</code></p></td>
@@ -17259,7 +17272,7 @@ Otherwise it is OK to omit the attribute.</td>
 <div class="sect3">
 <h4 id="_item_type_classification_and_service_accounting_code"><a class="anchor" href="#_item_type_classification_and_service_accounting_code"></a><a class="link" href="#_item_type_classification_and_service_accounting_code">5.19.6. Item type, classification and Service Accounting Code</a></h4>
 <div class="paragraph">
-<p>Every UAE invoice line MUST declare whether the item is goods, a service, or both, via the <strong>item type</strong> (BTAE-13). It is provided through the PUF item extension:</p>
+<p>Every UAE invoice line MUST declare whether the item is goods, a service, or both, via the <strong>item type</strong> (BTAE-13). It is provided through <code>cac:CommodityClassification/cbc:CommodityCode</code>:</p>
 </div>
 <table class="tableblock frame-all grid-all fit-content">
 <colgroup>
@@ -17274,16 +17287,16 @@ Otherwise it is OK to omit the attribute.</td>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>GOODS</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>G</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Goods</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>SERVICES</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>S</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Services</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>BOTH</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Mixed (both goods and services on the same line)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>B</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Both (goods and services on the same line)</p></td>
 </tr>
 </tbody>
 </table>
@@ -17293,39 +17306,43 @@ Otherwise it is OK to omit the attribute.</td>
 <div class="ulist">
 <ul>
 <li>
-<p>When item type is <code>GOODS</code> (or <code>BOTH</code>), the <strong>item classification</strong> (IBT-158) MUST be present and the classification scheme identifier (<code>@listID</code>) MUST be <code>HS</code> (Harmonised Commodity Description and Coding System).</p>
+<p>When item type is <code>G</code> (or <code>B</code>), the <strong>item classification</strong> (IBT-158) MUST be present and the classification scheme identifier (<code>@listID</code>) MUST be <code>HS</code> (Harmonised Commodity Description and Coding System).</p>
 </li>
 <li>
-<p>When item type is <code>SERVICES</code> (or <code>BOTH</code>), the <strong>Service Accounting Code</strong> (BTAE-17) MUST be present using <code>cac:AdditionalItemIdentification</code> with <code>@schemeID = 'SAC'</code>.</p>
+<p>When item type is <code>S</code> (or <code>B</code>), the <strong>Service Accounting Code</strong> (BTAE-17) MUST be present using <code>cac:AdditionalItemIdentification</code> with <code>@schemeID = 'SAC'</code>.</p>
 </li>
 </ul>
 </div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+Per the PINT-AE syntax, <code>cbc:ItemClassificationCode</code> (scheme <code>HS</code>) is mandatory (1..1) within every <code>cac:CommodityClassification</code>. A line that carries <code>cbc:CommodityCode</code> therefore also carries an <code>cbc:ItemClassificationCode</code>. A service line additionally provides the Service Accounting Code (BTAE-17) in <code>cac:AdditionalItemIdentification</code>.
+</td>
+</tr>
+</table>
+</div>
 <div class="paragraph">
 <p><strong>Example</strong><br>
-<em>Line for a service, carrying both the item type extension and the SAC code</em></p>
+<em>Line for a service, carrying the item type, the item classification and the SAC code</em></p>
 </div>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;cac:InvoiceLine&gt;</span>
   <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
   <span class="tag">&lt;cac:Item&gt;</span>
-    <span class="tag">&lt;cbc:Name&gt;</span>Consulting services<span class="tag">&lt;/cbc:Name&gt;</span>
     <span class="tag">&lt;cbc:Description&gt;</span>Q1 advisory engagement<span class="tag">&lt;/cbc:Description&gt;</span>
+    <span class="tag">&lt;cbc:Name&gt;</span>Consulting services<span class="tag">&lt;/cbc:Name&gt;</span>
     <span class="tag">&lt;cac:AdditionalItemIdentification&gt;</span>
       <span class="tag">&lt;cbc:ID</span> <span class="attribute-name">schemeID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">SAC</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>9983.11<span class="tag">&lt;/cbc:ID&gt;</span><i class="conum" data-value="1"></i><b>(1)</b>
     <span class="tag">&lt;/cac:AdditionalItemIdentification&gt;</span>
-    <span class="tag">&lt;ext:UBLExtensions&gt;</span>
-      <span class="tag">&lt;ext:UBLExtension&gt;</span>
-        <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:ItemExtension<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
-        <span class="tag">&lt;ext:ExtensionContent&gt;</span>
-          <span class="tag">&lt;puf:PageroExtension&gt;</span>
-            <span class="tag">&lt;puf:ItemExtension&gt;</span>
-              <span class="tag">&lt;puf:ItemType&gt;</span>SERVICES<span class="tag">&lt;/puf:ItemType&gt;</span><i class="conum" data-value="2"></i><b>(2)</b>
-            <span class="tag">&lt;/puf:ItemExtension&gt;</span>
-          <span class="tag">&lt;/puf:PageroExtension&gt;</span>
-        <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
-      <span class="tag">&lt;/ext:UBLExtension&gt;</span>
-    <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+    <span class="tag">&lt;cac:CommodityClassification&gt;</span>
+      <span class="tag">&lt;cbc:CommodityCode&gt;</span>S<span class="tag">&lt;/cbc:CommodityCode&gt;</span><i class="conum" data-value="2"></i><b>(2)</b>
+      <span class="tag">&lt;cbc:ItemClassificationCode</span> <span class="attribute-name">listID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">HS</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>8523.49.00<span class="tag">&lt;/cbc:ItemClassificationCode&gt;</span><i class="conum" data-value="3"></i><b>(3)</b>
+    <span class="tag">&lt;/cac:CommodityClassification&gt;</span>
   <span class="tag">&lt;/cac:Item&gt;</span>
 <span class="tag">&lt;/cac:InvoiceLine&gt;</span></code></pre>
 </div>
@@ -17334,11 +17351,15 @@ Otherwise it is OK to omit the attribute.</td>
 <table>
 <tr>
 <td><i class="conum" data-value="1"></i><b>1</b></td>
-<td>Service Accounting Code with <code>schemeID="SAC"</code>.</td>
+<td>Service Accounting Code with <code>schemeID="SAC"</code> (required for services, ibr-185-ae).</td>
 </tr>
 <tr>
 <td><i class="conum" data-value="2"></i><b>2</b></td>
-<td>Item type <code>SERVICES</code> provided through <code>puf:ItemExtension/puf:ItemType</code>.</td>
+<td>Item type <code>S</code> (Services) via <code>cac:CommodityClassification/cbc:CommodityCode</code>.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Item classification identifier, mandatory (1..1) within the <code>cac:CommodityClassification</code>; scheme <code>HS</code> (ibr-188-ae).</td>
 </tr>
 </table>
 </div>

--- a/specification/country-specifics/uae.adoc
+++ b/specification/country-specifics/uae.adoc
@@ -38,7 +38,7 @@ _Free-trade-zone invoice (FTZ flag in position 1)_
 
 The UAE Tax Registration Number (TRN) is provided as the VAT identifier on `cac:PartyTaxScheme/cbc:CompanyID` with the tax scheme code `VAT`. The TRN is 15 alphanumeric characters, starts with `1` and ends with `03` (e.g. `100000000000003`).
 
-When the supplier is not VAT-registered, the Tax Identification Number (TIN) is provided instead under `cac:PartyIdentification/cbc:ID`. The TIN is 10 numeric digits starting with `1` (e.g. `1000000000`).
+When the supplier is not VAT-registered, the Tax Identification Number (TIN) is provided instead under `cac:PartyIdentification/cbc:ID` with `@schemeID = 'AE:TIN'`. The TIN is 10 numeric digits starting with `1` (e.g. `1000000000`) and, for a VAT-registered party, is the first 10 digits of the TRN.
 
 *Example* +
 _Seller TRN_
@@ -61,6 +61,42 @@ _Seller TRN_
 </Invoice>
 ----
 <1> UAE TRN provided in `cac:PartyTaxScheme/cbc:CompanyID` with `cac:TaxScheme/cbc:ID = 'VAT'`.
+
+==== Electronic address (Participant Identifier)
+
+The seller and buyer electronic address (IBT-034 / IBT-049) is the Peppol *Participant Identifier* issued by the FTA. It MUST be the *10-digit TIN* under the Peppol EAS scheme `0235`.
+
+The TIN is the first 10 digits of the 15-character TRN. The full TRN MUST NOT be used as the electronic address — it belongs on `cac:PartyTaxScheme/cbc:CompanyID` (IBT-031 / IBT-048) only.
+
+[IMPORTANT]
+====
+The PUF-008 scheme code `AE:TIN` applies to `cac:PartyIdentification/cbc:ID`. It is *not* an endpoint scheme — `cbc:EndpointID/@schemeID` always carries the Peppol EAS code `0235`.
+====
+
+*Example* +
+_Seller with TRN `100000000000003` and the derived Participant Identifier_
+[source,xml]
+----
+<Invoice>
+  <!-- Code omitted for clarity -->
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0235">1000000000</cbc:EndpointID><!--1-->
+      <!-- Code omitted for clarity -->
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>100000000000003</cbc:CompanyID><!--2-->
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+</Invoice>
+----
+<1> Participant Identifier: scheme `0235` with the 10-digit TIN (the first 10 digits of the TRN).
+<2> The full 15-character TRN stays on `cac:PartyTaxScheme/cbc:CompanyID`.
+
+A party that is within scope of UAE e-invoicing but not registered for VAT has no TRN. It still has a TIN, obtained by registering with the FTA, and uses that TIN as its Participant Identifier.
 
 ==== Legal registration identifier
 
@@ -167,10 +203,10 @@ The item type drives two further requirements:
 * When item type is `G` (or `B`), the *item classification* (IBT-158) MUST be present and the classification scheme identifier (`@listID`) MUST be `HS` (Harmonised Commodity Description and Coding System).
 * When item type is `S` (or `B`), the *Service Accounting Code* (BTAE-17) MUST be present using `cac:AdditionalItemIdentification` with `@schemeID = 'SAC'`.
 
-NOTE: Per the PINT-AE syntax, `cbc:ItemClassificationCode` (scheme `HS`) is mandatory (1..1) within every `cac:CommodityClassification`. A line that carries `cbc:CommodityCode` therefore also carries an `cbc:ItemClassificationCode`. A service line additionally provides the Service Accounting Code (BTAE-17) in `cac:AdditionalItemIdentification`.
+NOTE: The PINT-AE syntax table shows `cbc:ItemClassificationCode` as 1..1 within `cac:CommodityClassification`, but the validation artefacts do not enforce this: `ibr-184-ae` requires the item classification only when the item type is `G` (or `B`), and `ibr-188-ae` constrains the scheme identifier only when a classification is actually present. A pure service line therefore carries `cbc:CommodityCode` alone and is classified by its Service Accounting Code (BTAE-17). Do not invent an HS code for a service — HS classifies goods, and a placeholder value would misreport the supply.
 
 *Example* +
-_Line for a service, carrying the item type, the item classification and the SAC code_
+_Line for a service, carrying the item type and the SAC code_
 [source,xml]
 ----
 <cac:InvoiceLine>
@@ -183,14 +219,12 @@ _Line for a service, carrying the item type, the item classification and the SAC
     </cac:AdditionalItemIdentification>
     <cac:CommodityClassification>
       <cbc:CommodityCode>S</cbc:CommodityCode><!--2-->
-      <cbc:ItemClassificationCode listID="HS">8523.49.00</cbc:ItemClassificationCode><!--3-->
     </cac:CommodityClassification>
   </cac:Item>
 </cac:InvoiceLine>
 ----
 <1> Service Accounting Code with `schemeID="SAC"` (required for services, ibr-185-ae).
-<2> Item type `S` (Services) via `cac:CommodityClassification/cbc:CommodityCode`.
-<3> Item classification identifier, mandatory (1..1) within the `cac:CommodityClassification`; scheme `HS` (ibr-188-ae).
+<2> Item type `S` (Services) via `cac:CommodityClassification/cbc:CommodityCode`. No `cbc:ItemClassificationCode` — services are not classified by HS.
 
 ==== VAT category, rate and exemption
 

--- a/specification/country-specifics/uae.adoc
+++ b/specification/country-specifics/uae.adoc
@@ -151,51 +151,46 @@ When the document currency is not AED, the following amounts MUST be additionall
 
 ==== Item type, classification and Service Accounting Code
 
-Every UAE invoice line MUST declare whether the item is goods, a service, or both, via the *item type* (BTAE-13). It is provided through the PUF item extension:
+Every UAE invoice line MUST declare whether the item is goods, a service, or both, via the *item type* (BTAE-13). It is provided through `cac:CommodityClassification/cbc:CommodityCode`:
 
 [%autowidth]
 |===
 |Code |Meaning
 
-|`GOODS` |Goods
-|`SERVICES` |Services
-|`BOTH` |Mixed (both goods and services on the same line)
+|`G` |Goods
+|`S` |Services
+|`B` |Both (goods and services on the same line)
 |===
 
 The item type drives two further requirements:
 
-* When item type is `GOODS` (or `BOTH`), the *item classification* (IBT-158) MUST be present and the classification scheme identifier (`@listID`) MUST be `HS` (Harmonised Commodity Description and Coding System).
-* When item type is `SERVICES` (or `BOTH`), the *Service Accounting Code* (BTAE-17) MUST be present using `cac:AdditionalItemIdentification` with `@schemeID = 'SAC'`.
+* When item type is `G` (or `B`), the *item classification* (IBT-158) MUST be present and the classification scheme identifier (`@listID`) MUST be `HS` (Harmonised Commodity Description and Coding System).
+* When item type is `S` (or `B`), the *Service Accounting Code* (BTAE-17) MUST be present using `cac:AdditionalItemIdentification` with `@schemeID = 'SAC'`.
+
+NOTE: Per the PINT-AE syntax, `cbc:ItemClassificationCode` (scheme `HS`) is mandatory (1..1) within every `cac:CommodityClassification`. A line that carries `cbc:CommodityCode` therefore also carries an `cbc:ItemClassificationCode`. A service line additionally provides the Service Accounting Code (BTAE-17) in `cac:AdditionalItemIdentification`.
 
 *Example* +
-_Line for a service, carrying both the item type extension and the SAC code_
+_Line for a service, carrying the item type, the item classification and the SAC code_
 [source,xml]
 ----
 <cac:InvoiceLine>
   <!-- Code omitted for clarity -->
   <cac:Item>
-    <cbc:Name>Consulting services</cbc:Name>
     <cbc:Description>Q1 advisory engagement</cbc:Description>
+    <cbc:Name>Consulting services</cbc:Name>
     <cac:AdditionalItemIdentification>
       <cbc:ID schemeID="SAC">9983.11</cbc:ID><!--1-->
     </cac:AdditionalItemIdentification>
-    <ext:UBLExtensions>
-      <ext:UBLExtension>
-        <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ItemExtension</ext:ExtensionURI>
-        <ext:ExtensionContent>
-          <puf:PageroExtension>
-            <puf:ItemExtension>
-              <puf:ItemType>SERVICES</puf:ItemType><!--2-->
-            </puf:ItemExtension>
-          </puf:PageroExtension>
-        </ext:ExtensionContent>
-      </ext:UBLExtension>
-    </ext:UBLExtensions>
+    <cac:CommodityClassification>
+      <cbc:CommodityCode>S</cbc:CommodityCode><!--2-->
+      <cbc:ItemClassificationCode listID="HS">8523.49.00</cbc:ItemClassificationCode><!--3-->
+    </cac:CommodityClassification>
   </cac:Item>
 </cac:InvoiceLine>
 ----
-<1> Service Accounting Code with `schemeID="SAC"`.
-<2> Item type `SERVICES` provided through `puf:ItemExtension/puf:ItemType`.
+<1> Service Accounting Code with `schemeID="SAC"` (required for services, ibr-185-ae).
+<2> Item type `S` (Services) via `cac:CommodityClassification/cbc:CommodityCode`.
+<3> Item classification identifier, mandatory (1..1) within the `cac:CommodityClassification`; scheme `HS` (ibr-188-ae).
 
 ==== VAT category, rate and exemption
 

--- a/specification/syntax/line-level/Item.adoc
+++ b/specification/syntax/line-level/Item.adoc
@@ -43,6 +43,10 @@ Country code from where the item origin.
 |**Commodity Classification. Nature Code.** +
 A code defined by a specific maintenance agency signifying the high-level nature of the commodity.
 
+|`cac:CommodityClassification/cbc:CommodityCode`
+|**Commodity Classification. Commodity Code.** +
+The type of commodity. Used by some jurisdictions to indicate whether the item is goods, a service, or both — see country specifics.
+
 |`cac:CommodityClassification/cbc:ItemClassificationCode`
 |**Item classification code** +
 The items classification code.


### PR DESCRIPTION
## Summary
Switches the UAE item type (BTAE-13) from the `puf:ItemType` extension to the native `cac:CommodityClassification/cbc:CommodityCode` (codes `G`/`S`/`B`), aligning with the PINT-AE syntax for a direct UBL mapping. `puf:ItemType` is retained elsewhere (still used by India).

## Changes
- **`specification/syntax/line-level/Item.adoc`**: add `cac:CommodityClassification/cbc:CommodityCode` to the line-item table (jurisdiction-neutral).
- **`specification/country-specifics/uae.adoc`**: item type codes `G`/`S`/`B` via `cbc:CommodityCode`; NOTE + services example. Per PINT-AE, `cbc:ItemClassificationCode` (scheme `HS`) is mandatory `1..1` within every `cac:CommodityClassification`, so every line (incl. services) carries one.
- **15 UAE examples**: converted to `cbc:CommodityCode` — goods = `G` + HS; services = `S` + HS + SAC; reverse-charge keeps `NatureCode`/`CommodityCode`/`ItemClassificationCode` order. README Item Type table updated.
- **`index.html`**: regenerated.

## Validation
- XSD: 204/204 pass.

## Notes
- HS `ItemClassificationCode` values on the **services** examples are illustrative placeholders (services have no natural HS code) — real senders supply the applicable classification.
- `index.html` carries some stylesheet churn from the local asciidoctor version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)