### PR TITLE
Add ExternalDeliveryType extension documentation and example

### DIFF
--- a/examples/PUF_Invoice_ComplianceAndExternalDelivery_Extensions.xml
+++ b/examples/PUF_Invoice_ComplianceAndExternalDelivery_Extensions.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generic PUF Billing Invoice showcasing the document-level ComplianceExtension
+     (ComplianceActivatedIndicator + SkipClearanceIndicator) and ExternalDeliveryType extensions. -->
+<Invoice xmlns:cac="urn:pagero:CommonAggregateComponents:1.0" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:puf="urn:pagero:ExtensionComponent:1.0" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns="urn:pagero:PageroUniversalFormat:Invoice:1.0">
+    <!-- Document-level compliance / external delivery extensions (Invoice root) -->
+    <ext:UBLExtensions>
+        <ext:UBLExtension>
+            <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ComplianceExtension</ext:ExtensionURI>
+            <ext:ExtensionContent>
+                <puf:PageroExtension>
+                    <puf:ComplianceExtension>
+                        <puf:ComplianceActivatedIndicator>true</puf:ComplianceActivatedIndicator>
+                        <puf:SkipClearanceIndicator>true</puf:SkipClearanceIndicator>
+                    </puf:ComplianceExtension>
+                </puf:PageroExtension>
+            </ext:ExtensionContent>
+        </ext:UBLExtension>
+        <ext:UBLExtension>
+            <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ExternalDeliveryType</ext:ExtensionURI>
+            <ext:ExtensionContent>
+                <puf:PageroExtension>
+                    <puf:ExternalDeliveryType>PROCESS_WITHOUT_DELIVERY</puf:ExternalDeliveryType>
+                </puf:PageroExtension>
+            </ext:ExtensionContent>
+        </ext:UBLExtension>
+    </ext:UBLExtensions>
+    <cbc:CustomizationID>urn:pagero.com:puf:billing:2.0</cbc:CustomizationID>
+    <cbc:ProfileID>urn:pagero.com:puf:billing:1.0</cbc:ProfileID>
+    <cbc:ID>123456</cbc:ID>
+    <cbc:IssueDate>2026-06-18</cbc:IssueDate>
+    <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+    <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cbc:EndpointID schemeID="0088">7300010000001</cbc:EndpointID>
+            <cac:PartyName>
+                <cbc:Name>Supplier Name</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Test Street 1</cbc:StreetName>
+                <cbc:CityName>Town</cbc:CityName>
+                <cbc:PostalZone>00000</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>SE123456123401</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Supplier Registration Name</cbc:RegistrationName>
+                <cbc:CompanyID schemeID="0007">1234561234</cbc:CompanyID>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cbc:EndpointID schemeID="0088">7300010000002</cbc:EndpointID>
+            <cac:PartyName>
+                <cbc:Name>Customer Name</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Customer Street</cbc:StreetName>
+                <cbc:CityName>Customer City</cbc:CityName>
+                <cbc:PostalZone>00000</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Customer Registration Name</cbc:RegistrationName>
+                <cbc:CompanyID schemeID="0007">987654-4321</cbc:CompanyID>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">125.00</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">125.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>10000</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="EA">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+        <cac:TaxTotal>
+            <cbc:TaxAmount currencyID="EUR">25.00</cbc:TaxAmount>
+            <cac:TaxSubtotal>
+                <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
+                <cbc:TaxAmount currencyID="EUR">25.00</cbc:TaxAmount>
+                <cac:TaxCategory>
+                    <cbc:ID schemeID="UNCL5305">S</cbc:ID>
+                    <cbc:Percent>25</cbc:Percent>
+                    <cac:TaxScheme>
+                        <cbc:ID>VAT</cbc:ID>
+                    </cac:TaxScheme>
+                </cac:TaxCategory>
+            </cac:TaxSubtotal>
+        </cac:TaxTotal>
+        <cac:Item>
+            <cbc:Name>Article 1</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID schemeID="UNCL5305">S</cbc:ID>
+                <cbc:Percent>25</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+            <cbc:BaseQuantity unitCode="EA">1</cbc:BaseQuantity>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>

--- a/index.html
+++ b/index.html
@@ -650,17 +650,18 @@ table.CodeRay td.code{padding:0 0 0 .75em}
 <li><a href="#_self_billing_indicator">4.1.11. Self Billing Indicator</a></li>
 <li><a href="#_simplified_indicator">4.1.12. Simplified Indicator</a></li>
 <li><a href="#_compliance_extension">4.1.13. Compliance Extension</a></li>
-<li><a href="#_orderreference">4.1.14. OrderReference</a></li>
-<li><a href="#_billingreference">4.1.15. BillingReference</a></li>
-<li><a href="#_contractdocumentreference">4.1.16. ContractDocumentReference</a></li>
-<li><a href="#_party">4.1.17. Party</a></li>
-<li><a href="#_delivery">4.1.18. Delivery</a></li>
-<li><a href="#_paymentterms">4.1.19. PaymentTerms</a></li>
-<li><a href="#_taxsubtotal">4.1.20. TaxSubTotal</a></li>
-<li><a href="#_legalmonetarytotal">4.1.21. LegalMonetaryTotal</a></li>
-<li><a href="#_prepaidpayment">4.1.22. PrepaidPayment</a></li>
-<li><a href="#_languagecode">4.1.23. LanguageCode</a></li>
-<li><a href="#_restricted_information_party">4.1.24. Restricted Information Party</a></li>
+<li><a href="#_external_delivery_type">4.1.14. External Delivery Type</a></li>
+<li><a href="#_orderreference">4.1.15. OrderReference</a></li>
+<li><a href="#_billingreference">4.1.16. BillingReference</a></li>
+<li><a href="#_contractdocumentreference">4.1.17. ContractDocumentReference</a></li>
+<li><a href="#_party">4.1.18. Party</a></li>
+<li><a href="#_delivery">4.1.19. Delivery</a></li>
+<li><a href="#_paymentterms">4.1.20. PaymentTerms</a></li>
+<li><a href="#_taxsubtotal">4.1.21. TaxSubTotal</a></li>
+<li><a href="#_legalmonetarytotal">4.1.22. LegalMonetaryTotal</a></li>
+<li><a href="#_prepaidpayment">4.1.23. PrepaidPayment</a></li>
+<li><a href="#_languagecode">4.1.24. LanguageCode</a></li>
+<li><a href="#_restricted_information_party">4.1.25. Restricted Information Party</a></li>
 </ul>
 </li>
 <li><a href="#_line_level">4.2. Line level</a>
@@ -7686,7 +7687,71 @@ When set to <code>true</code>, the document must not be sent to a clearance auth
 </div>
 </div>
 <div class="sect3">
-<h4 id="_orderreference"><a class="anchor" href="#_orderreference"></a><a class="link" href="#_orderreference">4.1.14. OrderReference</a></h4>
+<h4 id="_external_delivery_type"><a class="anchor" href="#_external_delivery_type"></a><a class="link" href="#_external_delivery_type">4.1.14. External Delivery Type</a></h4>
+<div class="admonitionblock warning">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-warning" title="Warning"></i>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>This extension is provided for specific integration scenarios; most integrations producing PUF for Pagero Online will not need it. Only use it if you are aware of the consequences for how Pagero Online processes, validates, clears, routes and delivers the document. If you are uncertain whether or how to use it, contact Pagero / Thomson Reuters before doing so.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>Below table shows the definition of the element added to the extension <code>puf:PageroExtension/puf:ExternalDeliveryType</code>. This extension is placed in the document-level <code>ext:UBLExtensions</code> on the <code>Invoice</code> / <code>CreditNote</code> root element.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 51. Element added in puf:ExternalDeliveryType.</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Element</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>puf:ExternalDeliveryType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>External delivery type</strong><br>
+Indicates that the document should be processed without standard Pagero routing and/or delivery.<br>
+<strong>One of:</strong> <code>PROCESS_WITHOUT_DELIVERY</code> (the document is processed but not delivered by Pagero) or <code>PROCESS_WITHOUT_ROUTING</code> (the document is processed but neither routed nor delivered by Pagero).</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>See example below as well as the URI to be used for this extension.</p>
+</div>
+<div class="paragraph">
+<p><strong>Example</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
+    <span class="tag">&lt;ext:UBLExtensions&gt;</span>
+        <span class="tag">&lt;ext:UBLExtension&gt;</span>
+            <span class="tag">&lt;ext:ExtensionURI&gt;</span>urn:pagero:ExtensionComponent:1.0:PageroExtension:ExternalDeliveryType<span class="tag">&lt;/ext:ExtensionURI&gt;</span>
+            <span class="tag">&lt;ext:ExtensionContent&gt;</span>
+                <span class="tag">&lt;puf:PageroExtension&gt;</span>
+                    <span class="tag">&lt;puf:ExternalDeliveryType&gt;</span>PROCESS_WITHOUT_DELIVERY<span class="tag">&lt;/puf:ExternalDeliveryType&gt;</span>
+                <span class="tag">&lt;/puf:PageroExtension&gt;</span>
+            <span class="tag">&lt;/ext:ExtensionContent&gt;</span>
+        <span class="tag">&lt;/ext:UBLExtension&gt;</span>
+    <span class="tag">&lt;/ext:UBLExtensions&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+<span class="tag">&lt;/Invoice&gt;</span></code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_orderreference"><a class="anchor" href="#_orderreference"></a><a class="link" href="#_orderreference">4.1.15. OrderReference</a></h4>
 <div class="paragraph">
 <p>The UBL extension to be used for below elements can be found <a href="#_cacorderreference">here</a>.</p>
 </div>
@@ -7736,7 +7801,7 @@ When set to <code>true</code>, the document must not be sent to a clearance auth
 <p>Below table show the definition of the new element added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 51. Elements added in puf:OrderReferenceExtension</caption>
+<caption class="title">Table 52. Elements added in puf:OrderReferenceExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -7786,7 +7851,7 @@ Date of the sales order, date should be formatted yyyy-mm-dd.</p></td>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_billingreference"><a class="anchor" href="#_billingreference"></a><a class="link" href="#_billingreference">4.1.15. BillingReference</a></h4>
+<h4 id="_billingreference"><a class="anchor" href="#_billingreference"></a><a class="link" href="#_billingreference">4.1.16. BillingReference</a></h4>
 <div class="paragraph">
 <p>The UBL extension to be used for below elements can be found <a href="#_cacbillingreference">here</a>.</p>
 </div>
@@ -7832,7 +7897,7 @@ Date of the sales order, date should be formatted yyyy-mm-dd.</p></td>
 </table>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 52. Elements added in puf:BillingReferenceExtension</caption>
+<caption class="title">Table 53. Elements added in puf:BillingReferenceExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -7934,7 +7999,7 @@ The equivalence surcharge amount of the referenced document. Used in Spain for c
 </div>
 </div>
 <div class="sect3">
-<h4 id="_contractdocumentreference"><a class="anchor" href="#_contractdocumentreference"></a><a class="link" href="#_contractdocumentreference">4.1.16. ContractDocumentReference</a></h4>
+<h4 id="_contractdocumentreference"><a class="anchor" href="#_contractdocumentreference"></a><a class="link" href="#_contractdocumentreference">4.1.17. ContractDocumentReference</a></h4>
 <div class="paragraph">
 <p>The UBL extension to be used for below elements can be found <a href="#_caccontractdocumentreference">here</a>.</p>
 </div>
@@ -7978,7 +8043,7 @@ The equivalence surcharge amount of the referenced document. Used in Spain for c
 </table>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 53. Elements added in puf:ContractDocumentReferenceExtension</caption>
+<caption class="title">Table 54. Elements added in puf:ContractDocumentReferenceExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -8033,7 +8098,7 @@ Issue date for the buyer referenced contract document, date should be formatted 
 </div>
 </div>
 <div class="sect3">
-<h4 id="_party"><a class="anchor" href="#_party"></a><a class="link" href="#_party">4.1.17. Party</a></h4>
+<h4 id="_party"><a class="anchor" href="#_party"></a><a class="link" href="#_party">4.1.18. Party</a></h4>
 <div class="paragraph">
 <p>The UBL extension to be used for below elements can be found in <a href="#_party">cac:Party</a>.</p>
 </div>
@@ -8083,7 +8148,7 @@ Issue date for the buyer referenced contract document, date should be formatted 
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 54. Elements added in puf:PartyExtension</caption>
+<caption class="title">Table 55. Elements added in puf:PartyExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -8229,7 +8294,7 @@ The <code>puf:RoleCode</code> must be coded using the <a href="https://pagero.gi
 </div>
 </div>
 <div class="sect3">
-<h4 id="_delivery"><a class="anchor" href="#_delivery"></a><a class="link" href="#_delivery">4.1.18. Delivery</a></h4>
+<h4 id="_delivery"><a class="anchor" href="#_delivery"></a><a class="link" href="#_delivery">4.1.19. Delivery</a></h4>
 <div class="paragraph">
 <p>The UBL extension to be used for below elements can be found <a href="#_cacdelivery">here</a>.</p>
 </div>
@@ -8279,7 +8344,7 @@ The <code>puf:RoleCode</code> must be coded using the <a href="https://pagero.gi
 <p>Below table show the definition of the additional elements added to the delivery extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 55. Elements added in puf:DeliveryExtension</caption>
+<caption class="title">Table 56. Elements added in puf:DeliveryExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -8367,7 +8432,7 @@ A code for the delivery method.</p></td>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_paymentterms"><a class="anchor" href="#_paymentterms"></a><a class="link" href="#_paymentterms">4.1.19. PaymentTerms</a></h4>
+<h4 id="_paymentterms"><a class="anchor" href="#_paymentterms"></a><a class="link" href="#_paymentterms">4.1.20. PaymentTerms</a></h4>
 <div class="paragraph">
 <p>The UBL extension to be used for below elements can be found <a href="#_cacpaymentterms">here</a>.</p>
 </div>
@@ -8417,7 +8482,7 @@ A code for the delivery method.</p></td>
 <p>Below table shows the definition of the extended element.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 56. Elements added in puf:PaymentTermsExtension</caption>
+<caption class="title">Table 57. Elements added in puf:PaymentTermsExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -8467,7 +8532,7 @@ Penalty text due to late payment, if the need of explicitly stating a penalty te
 </div>
 </div>
 <div class="sect3">
-<h4 id="_taxsubtotal"><a class="anchor" href="#_taxsubtotal"></a><a class="link" href="#_taxsubtotal">4.1.20. TaxSubTotal</a></h4>
+<h4 id="_taxsubtotal"><a class="anchor" href="#_taxsubtotal"></a><a class="link" href="#_taxsubtotal">4.1.21. TaxSubTotal</a></h4>
 <div class="paragraph">
 <p>The UBL extension to be used for below elements can be found <a href="#_cactaxtotal">here</a>.</p>
 </div>
@@ -8519,7 +8584,7 @@ Penalty text due to late payment, if the need of explicitly stating a penalty te
 <p>Below table lists all additional elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 57. Elements added in puf:TaxSubtotalExtension</caption>
+<caption class="title">Table 58. Elements added in puf:TaxSubtotalExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -8904,7 +8969,7 @@ For valid values see code list <a href="https://pagero.github.io/puf-code-lists/
 </div>
 </div>
 <div class="sect3">
-<h4 id="_legalmonetarytotal"><a class="anchor" href="#_legalmonetarytotal"></a><a class="link" href="#_legalmonetarytotal">4.1.21. LegalMonetaryTotal</a></h4>
+<h4 id="_legalmonetarytotal"><a class="anchor" href="#_legalmonetarytotal"></a><a class="link" href="#_legalmonetarytotal">4.1.22. LegalMonetaryTotal</a></h4>
 <div class="paragraph">
 <p>The UBL extension to be used for below elements can be found <a href="#_caclegalmonetarytotal">here</a>.</p>
 </div>
@@ -8954,7 +9019,7 @@ For valid values see code list <a href="https://pagero.github.io/puf-code-lists/
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 58. Elements added in puf:LegalMonetaryTotalExtension</caption>
+<caption class="title">Table 59. Elements added in puf:LegalMonetaryTotalExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -9178,7 +9243,7 @@ Please note that tax has been excluded in above example.
 </div>
 </div>
 <div class="sect3">
-<h4 id="_prepaidpayment"><a class="anchor" href="#_prepaidpayment"></a><a class="link" href="#_prepaidpayment">4.1.22. PrepaidPayment</a></h4>
+<h4 id="_prepaidpayment"><a class="anchor" href="#_prepaidpayment"></a><a class="link" href="#_prepaidpayment">4.1.23. PrepaidPayment</a></h4>
 <div class="paragraph">
 <p>The UBL extension to be used for below elements can be found <a href="#_cacprepaidpayment">here</a>.</p>
 </div>
@@ -9225,7 +9290,7 @@ Please note that tax has been excluded in above example.
 <p>Below table shows the definition of the extended element.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 59. Elements added in puf:PrepaidPaymentExtension</caption>
+<caption class="title">Table 60. Elements added in puf:PrepaidPaymentExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -9386,7 +9451,7 @@ For valid values see code list <a href="https://pagero.github.io/puf-code-lists/
 </div>
 </div>
 <div class="sect3">
-<h4 id="_languagecode"><a class="anchor" href="#_languagecode"></a><a class="link" href="#_languagecode">4.1.23. LanguageCode</a></h4>
+<h4 id="_languagecode"><a class="anchor" href="#_languagecode"></a><a class="link" href="#_languagecode">4.1.24. LanguageCode</a></h4>
 <div class="paragraph">
 <p>In order to specify language code for the system generated PDF presentation in Pagero Online, a segment for this is added as Extension.</p>
 </div>
@@ -9448,7 +9513,7 @@ Please contact us to learn which languages are available.
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 60. Elements added to puf:PageroExtension/puf:LanguageCode</caption>
+<caption class="title">Table 61. Elements added to puf:PageroExtension/puf:LanguageCode</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -9490,7 +9555,7 @@ Must be in lower case alpha, ISO 639-1, format.</p></td>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_restricted_information_party"><a class="anchor" href="#_restricted_information_party"></a><a class="link" href="#_restricted_information_party">4.1.24. Restricted Information Party</a></h4>
+<h4 id="_restricted_information_party"><a class="anchor" href="#_restricted_information_party"></a><a class="link" href="#_restricted_information_party">4.1.25. Restricted Information Party</a></h4>
 <div class="paragraph">
 <p>RestrictedInformationParty has been added on document level in order to cater the need for additional country specific parties</p>
 </div>
@@ -9560,7 +9625,7 @@ If country specific information is available as restricted information party, th
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 61. Elements added to puf:PageroExtension/puf:RestrictedInformationParty</caption>
+<caption class="title">Table 62. Elements added to puf:PageroExtension/puf:RestrictedInformationParty</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -9766,7 +9831,7 @@ If country specific information is available as restricted information value, th
 <p>Below table show the definition of the new element added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 62. Elements added in puf:RestrictedInformation</caption>
+<caption class="title">Table 63. Elements added in puf:RestrictedInformation</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -9875,7 +9940,7 @@ Value relevant to the assigned key.</p></td>
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 63. Elements added to puf:LineExtension</caption>
+<caption class="title">Table 64. Elements added to puf:LineExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -9995,7 +10060,7 @@ For valid values see code list <a href="https://pagero.github.io/puf-code-lists/
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 64. Elements added to puf:LineExtension</caption>
+<caption class="title">Table 65. Elements added to puf:LineExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -10118,7 +10183,7 @@ For valid values see code list <a href="https://pagero.github.io/puf-code-lists/
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 65. Elements added to puf:LineExtension</caption>
+<caption class="title">Table 66. Elements added to puf:LineExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -10238,7 +10303,7 @@ For valid values see code list <a href="https://pagero.github.io/puf-code-lists/
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 66. Elements added to puf:LineExtension</caption>
+<caption class="title">Table 67. Elements added to puf:LineExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -10364,7 +10429,7 @@ For valid values see code list <a href="https://pagero.github.io/puf-code-lists/
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 67. Elements added to puf:LineExtension/puf:OriginatorDocumentReference</caption>
+<caption class="title">Table 68. Elements added to puf:LineExtension/puf:OriginatorDocumentReference</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -10475,7 +10540,7 @@ Date of issue of the referenced tender, date should be formatted "yyyy-mm-dd".</
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 68. Elements added to puf:LineExtension/puf:ProjectReference</caption>
+<caption class="title">Table 69. Elements added to puf:LineExtension/puf:ProjectReference</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -10586,7 +10651,7 @@ Identification of the project reference.</p></td>
 <p>Below table show the definition of the new element added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 69. Elements added in puf:OrderLineReference</caption>
+<caption class="title">Table 70. Elements added in puf:OrderLineReference</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -10700,7 +10765,7 @@ Date of the sales order, date should be formatted "yyyy-mm-dd".</p></td>
 <p>Below table shows the definition of the new elements added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 70. Elements added to puf:LineExtension/puf:ContractDocumentReference</caption>
+<caption class="title">Table 71. Elements added to puf:LineExtension/puf:ContractDocumentReference</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -10776,7 +10841,7 @@ Issue date for the buyer referenced contract document, date should be formatted 
 <p>The structure used from <code>PUF-ExtensionComponent.xsd</code> is <code>PageroExtension/LineExtension</code>.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 71. Sub-line elements</caption>
+<caption class="title">Table 72. Sub-line elements</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -10946,7 +11011,7 @@ Issue date for the buyer referenced contract document, date should be formatted 
 <p>Below table show the definition of the new element added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 72. Elements added to puf:ItemExtension</caption>
+<caption class="title">Table 73. Elements added to puf:ItemExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -11051,7 +11116,7 @@ Type of item, valid values are <code>GOODS</code> or <code>SERVICE</code>.</p></
 <p>Below table show the definition of the new element added to the extension.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 73. Elements added to puf:PriceExtension</caption>
+<caption class="title">Table 74. Elements added to puf:PriceExtension</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -18059,7 +18124,7 @@ For enhanced search functionality in Pagero Online, it is recommended to use a c
 <p>Below is a list of countries where PUF can be used as the source for tax data reporting with distribution solely to tax authorities.</p>
 </div>
 <table class="tableblock frame-all grid-all fit-content stretch">
-<caption class="title">Table 74. Table of PUF supported countries for Tax data reporting</caption>
+<caption class="title">Table 75. Table of PUF supported countries for Tax data reporting</caption>
 <colgroup>
 <col>
 <col>
@@ -18214,7 +18279,7 @@ If no entry type is sent system will default to type Invoice.
 <div class="sect2">
 <h3 id="_code_lists_for_coded_elements"><a class="anchor" href="#_code_lists_for_coded_elements"></a><a class="link" href="#_code_lists_for_coded_elements">7.1. Code lists for coded elements</a></h3>
 <table class="tableblock frame-all grid-all fit-content stretch">
-<caption class="title">Table 75. Table of the code lists used</caption>
+<caption class="title">Table 76. Table of the code lists used</caption>
 <colgroup>
 <col>
 <col>
@@ -18395,7 +18460,7 @@ cbc:ItemClassificationCode/@listID</code></p></td>
 <p>The validation artefacts are also available on <a href="https://github.com/pagero/puf-billing/tree/master/validation-artefacts" target="_blank" rel="noopener">GitHub</a>.</p>
 </div>
 <table class="tableblock frame-all grid-all fit-content stretch">
-<caption class="title">Table 76. Schematron rules in PUF</caption>
+<caption class="title">Table 77. Schematron rules in PUF</caption>
 <colgroup>
 <col>
 <col>
@@ -18575,7 +18640,7 @@ The "Require ext:UBLExtensions"-column indicates whether or not the use of UBL e
 </table>
 </div>
 <table class="tableblock frame-all grid-all fit-content stretch">
-<caption class="title">Table 77. Table of supported countries</caption>
+<caption class="title">Table 78. Table of supported countries</caption>
 <colgroup>
 <col>
 <col>

--- a/specification/extensions/document-level/ExternalDeliveryType.adoc
+++ b/specification/extensions/document-level/ExternalDeliveryType.adoc
@@ -1,0 +1,38 @@
+[WARNING]
+====
+This extension is provided for specific integration scenarios; most integrations producing PUF for Pagero Online will not need it. Only use it if you are aware of the consequences for how Pagero Online processes, validates, clears, routes and delivers the document. If you are uncertain whether or how to use it, contact Pagero / Thomson Reuters before doing so.
+====
+
+Below table shows the definition of the element added to the extension `puf:PageroExtension/puf:ExternalDeliveryType`. This extension is placed in the document-level `ext:UBLExtensions` on the `Invoice` / `CreditNote` root element.
+
+.Element added in puf:ExternalDeliveryType.
+[%stretch,cols="1,1"]
+|===
+|Element |Description
+
+|`puf:ExternalDeliveryType`
+|**External delivery type** +
+Indicates that the document should be processed without standard Pagero routing and/or delivery. +
+*One of:* `PROCESS_WITHOUT_DELIVERY` (the document is processed but not delivered by Pagero) or `PROCESS_WITHOUT_ROUTING` (the document is processed but neither routed nor delivered by Pagero).
+
+|===
+
+See example below as well as the URI to be used for this extension.
+
+*Example*
+[source,xml]
+----
+<Invoice>
+    <ext:UBLExtensions>
+        <ext:UBLExtension>
+            <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ExternalDeliveryType</ext:ExtensionURI>
+            <ext:ExtensionContent>
+                <puf:PageroExtension>
+                    <puf:ExternalDeliveryType>PROCESS_WITHOUT_DELIVERY</puf:ExternalDeliveryType>
+                </puf:PageroExtension>
+            </ext:ExtensionContent>
+        </ext:UBLExtension>
+    </ext:UBLExtensions>
+    <!-- Code omitted for clarity -->
+</Invoice>
+----

--- a/specification/extensions/extensions-document-level.adoc
+++ b/specification/extensions/extensions-document-level.adoc
@@ -55,6 +55,10 @@ include::document-level/Simplified.adoc[]
 
 include::document-level/ComplianceExtension.adoc[]
 
+==== External Delivery Type
+
+include::document-level/ExternalDeliveryType.adoc[]
+
 ==== OrderReference
 
 include::document-level/OrderReferenceExtension.adoc[]


### PR DESCRIPTION
Document the document-level puf:ExternalDeliveryType extension (already present in the XSD) mirroring the puf-invoice-response specification, and add a generic Invoice example showcasing the ComplianceExtension and ExternalDeliveryType extensions. Regenerate index.html.