### PR TITLE
Fix BT-8 VAT point date code binding in France examples (AB#5642938)

### DIFF
--- a/examples/country-specific-examples/france/PUF_France_UC32a_MonthlyPayments_AdditionalDue.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC32a_MonthlyPayments_AdditionalDue.xml
@@ -56,7 +56,7 @@
     - BT-23: No special business process code (standard reconciliation)
     - BT-113: Prepaid amount = 1,080.00 EUR (sum of monthly payments)
     - BT-115: Amount due = 144.00 EUR (positive - additional payment required)
-    - BT-8: Value added tax point date = meter reading date (actual consumption date)
+    - BT-8: Value added tax point date code = 432 (Paid to date) - VAT sur les encaissements
     
     Business Context:
     SELLER: ÉnergieVerte Provence SAS (electricity supplier)
@@ -134,9 +134,6 @@
     <cbc:Note>#BAR#B2C</cbc:Note>
     <cbc:Note>#AAB#Pas d'escompte pour paiement anticipé</cbc:Note>
     
-    <!-- BT-7: Tax point date (Meter reading date - actual consumption determination) -->
-    <cbc:TaxPointDate>2026-01-05</cbc:TaxPointDate>
-    
     <!-- BT-5: Invoice currency code -->
     <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
     
@@ -146,6 +143,10 @@
         <cbc:StartDate>2025-01-01</cbc:StartDate>
         <!-- BT-74: Invoicing period end date -->
         <cbc:EndDate>2025-12-31</cbc:EndDate>
+        <!-- BT-8: Value added tax point date code = 432 (Paid to date) - seller has NOT opted for
+             "TVA sur les débits", so VAT is exigible on collection. BT-7 is not used in France
+             and is mutually exclusive with BT-8 (BR-CO-03). -->
+        <cbc:DescriptionCode>432</cbc:DescriptionCode>
     </cac:InvoicePeriod>
 
     <!-- BT-13: Contract reference -->

--- a/examples/country-specific-examples/france/PUF_France_UC32b_MonthlyPayments_CreditDue.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC32b_MonthlyPayments_CreditDue.xml
@@ -111,8 +111,6 @@
 
     <!-- BT-2: Credit note issue date (Reconciliation credit note after meter reading) -->
     <cbc:IssueDate>2026-01-18</cbc:IssueDate>
-    <!-- BT-7: Tax point date (Meter reading date - actual consumption determination) -->
-    <cbc:TaxPointDate>2026-01-08</cbc:TaxPointDate>
     <!-- BT-3: Invoice type code = 381 (Credit note - for refund/overpayment scenario)
          BT-23: Business process type = S1 (Services credit note - energy supply) -->
     <cbc:CreditNoteTypeCode name="S1">381</cbc:CreditNoteTypeCode>
@@ -134,6 +132,10 @@
         <cbc:StartDate>2025-01-01</cbc:StartDate>
         <!-- BT-74: Invoicing period end date -->
         <cbc:EndDate>2025-12-31</cbc:EndDate>
+        <!-- BT-8: Value added tax point date code = 432 (Paid to date) - seller has NOT opted for
+             "TVA sur les débits", so VAT is exigible on collection. BT-7 is not used in France
+             and is mutually exclusive with BT-8 (BR-CO-03). -->
+        <cbc:DescriptionCode>432</cbc:DescriptionCode>
     </cac:InvoicePeriod>
     <!-- BT-13: Contract reference -->
     <cac:ContractDocumentReference>

--- a/examples/tax-data-report/country-specific-examples/france/PUF_FR_PURCHASE_INVOICE_TDR_CROSSBORDER_Bi2B_DRAFT - RECTIFICATION.xml
+++ b/examples/tax-data-report/country-specific-examples/france/PUF_FR_PURCHASE_INVOICE_TDR_CROSSBORDER_Bi2B_DRAFT - RECTIFICATION.xml
@@ -72,8 +72,8 @@
         <cbc:StartDate>2025-12-01</cbc:StartDate>
         <!-- BT-74 - Invoicing period end date -->
         <cbc:EndDate>2026-01-31</cbc:EndDate>
-        <!-- BT-8 - TAX point date code -->
-        <cbc:Description>3</cbc:Description>
+        <!-- BT-8 - TAX point date code. UNCL2005 subset: 3 (invoice issue date), 35 (delivery date), 432 (paid to date) -->
+        <cbc:DescriptionCode>3</cbc:DescriptionCode>
     </cac:InvoicePeriod>
     <!-- BG-4 Seller -->
     <cac:AccountingSupplierParty>

--- a/examples/tax-data-report/country-specific-examples/france/PUF_FR_PURCHASE_INVOICE_TDR_CROSSBORDER_Bi2B_DRAFT.xml
+++ b/examples/tax-data-report/country-specific-examples/france/PUF_FR_PURCHASE_INVOICE_TDR_CROSSBORDER_Bi2B_DRAFT.xml
@@ -62,8 +62,8 @@
         <cbc:StartDate>2025-12-01</cbc:StartDate>
         <!-- BT-74 - Invoicing period end date -->
         <cbc:EndDate>2026-01-31</cbc:EndDate>
-        <!-- BT-8 - TAX point date code -->
-        <cbc:Description>3</cbc:Description>
+        <!-- BT-8 - TAX point date code. UNCL2005 subset: 3 (invoice issue date), 35 (delivery date), 432 (paid to date) -->
+        <cbc:DescriptionCode>3</cbc:DescriptionCode>
     </cac:InvoicePeriod>
     <!-- BG-4 Seller -->
     <cac:AccountingSupplierParty>

--- a/examples/tax-data-report/country-specific-examples/france/PUF_FR_SALES_INVOICE_TDR_CROSSBORDER_B2Bi_DRAFT.xml
+++ b/examples/tax-data-report/country-specific-examples/france/PUF_FR_SALES_INVOICE_TDR_CROSSBORDER_B2Bi_DRAFT.xml
@@ -62,8 +62,8 @@
         <cbc:StartDate>2025-12-01</cbc:StartDate>
         <!-- BT-74 - Invoicing period end date -->
         <cbc:EndDate>2026-01-31</cbc:EndDate>
-        <!-- BT-8 - TAX point date code -->
-        <cbc:Description>3</cbc:Description>
+        <!-- BT-8 - TAX point date code. UNCL2005 subset: 3 (invoice issue date), 35 (delivery date), 432 (paid to date) -->
+        <cbc:DescriptionCode>3</cbc:DescriptionCode>
     </cac:InvoicePeriod>
     <!-- BG-4 Seller -->
     <cac:AccountingSupplierParty>

--- a/index.html
+++ b/index.html
@@ -1730,6 +1730,7 @@ Free text, the element can be iterated multiple times.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>cbc:TaxPointDate</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>VAT point date</strong><br>
 This element should be filled in if the date when VAT become liable for seller and buyer is different from the invoice issue date.<br>
+Mutually exclusive with the VAT point date code <code>cac:InvoicePeriod/cbc:DescriptionCode</code> (BT-8).<br>
 <em>Format "YYYY-MM-DD".</em></p></td>
 </tr>
 </tbody>
@@ -1918,6 +1919,13 @@ Reference assigned by the buyer for internal routing.</p></td>
 <em>Format "YYYY-MM-DD".</em></p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cbc:DescriptionCode</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>VAT point date code</strong><br>
+The code of the date when VAT becomes accountable for the seller and for the buyer. Used when the VAT point date is not known when the document is issued.<br>
+Mutually exclusive with <code>cbc:TaxPointDate</code> (BT-7).<br>
+Valid values, a subset of UNTDID 2005: <code>3</code> (Invoice document issue date); <code>35</code> (Delivery date, actual); <code>432</code> (Paid to date).</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>cbc:Description</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Invoicing period description</strong><br>
 Description of the billing period (free text).</p></td>
@@ -1935,6 +1943,7 @@ Description of the billing period (free text).</p></td>
   <span class="tag">&lt;cac:InvoicePeriod&gt;</span>
       <span class="tag">&lt;cbc:StartDate&gt;</span>2021-01-01<span class="tag">&lt;/cbc:StartDate&gt;</span>
       <span class="tag">&lt;cbc:EndDate&gt;</span>2021-01-31<span class="tag">&lt;/cbc:EndDate&gt;</span>
+      <span class="tag">&lt;cbc:DescriptionCode&gt;</span>35<span class="tag">&lt;/cbc:DescriptionCode&gt;</span>
       <span class="tag">&lt;cbc:Description&gt;</span>Description of invoice period<span class="tag">&lt;/cbc:Description&gt;</span>
   <span class="tag">&lt;/cac:InvoicePeriod&gt;</span>
   <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>

--- a/specification/syntax/document-level/InvoicePeriod.adoc
+++ b/specification/syntax/document-level/InvoicePeriod.adoc
@@ -10,6 +10,12 @@ _Format "YYYY-MM-DD"._
 |**Invoicing period end date** +
 _Format "YYYY-MM-DD"._
 
+|`cbc:DescriptionCode`
+|**VAT point date code** +
+The code of the date when VAT becomes accountable for the seller and for the buyer. Used when the VAT point date is not known when the document is issued. +
+Mutually exclusive with `cbc:TaxPointDate` (BT-7). +
+Valid values, a subset of UNTDID 2005: `3` (Invoice document issue date); `35` (Delivery date, actual); `432` (Paid to date).
+
 |`cbc:Description`
 |**Invoicing period description** + 
 Description of the billing period (free text).
@@ -24,6 +30,7 @@ _cac:InvoicePeriod with example values_
   <cac:InvoicePeriod>
       <cbc:StartDate>2021-01-01</cbc:StartDate>
       <cbc:EndDate>2021-01-31</cbc:EndDate>
+      <cbc:DescriptionCode>35</cbc:DescriptionCode>
       <cbc:Description>Description of invoice period</cbc:Description>
   </cac:InvoicePeriod>
   <!-- Code omitted for clarity -->

--- a/specification/syntax/document-level/TaxPointDate.adoc
+++ b/specification/syntax/document-level/TaxPointDate.adoc
@@ -4,6 +4,7 @@
 |`cbc:TaxPointDate`
 |**VAT point date** +
 This element should be filled in if the date when VAT become liable for seller and buyer is different from the invoice issue date. +
+Mutually exclusive with the VAT point date code `cac:InvoicePeriod/cbc:DescriptionCode` (BT-8). +
 _Format "YYYY-MM-DD"._
 
 |===


### PR DESCRIPTION
Resolves the two discrepancies reported in ADO Support Request [5642938](https://dev.azure.com/tr-tax/TaxTrade/_workitems/edit/5642938).

## 1. France TDR examples used the wrong element for BT-8

BT-8 (Value added tax point date code) binds to `Invoice/cac:InvoicePeriod/cbc:DescriptionCode`. The France TDR examples used `cbc:Description`, which is the free-text invoicing period description — a different element.

Sources:
- **Peppol BIS Billing 3.0** — [`cac:InvoicePeriod/cbc:DescriptionCode`](https://docs.peppol.eu/poacc/billing/3.0/syntax/ubl-invoice/cac-InvoicePeriod/cbc-DescriptionCode/) carries BT-8; code list [VAT date code (UNCL2005 subset)](https://docs.peppol.eu/poacc/billing/3.0/codelist/UNCL2005/) = `3` (Invoice document issue date time), `35` (Delivery date/time, actual), `432` (Paid to date); rules BR-CO-03, BR-CL-06, PEPPOL-EN16931-CL006.
- **EN 16931 (CEN schematron)** — BR-CO-03 evaluates `cac:InvoicePeriod/cbc:DescriptionCode` against `cbc:TaxPointDate`.
- **French external specifications (Flux 1 / annexe 1)** — BT-8 XPath `/Invoice/cac:InvoicePeriod/cbc:DescriptionCode`; `3` = date de la facture (TVA sur les débits), `35` = date de livraison (débits), `432` = date de paiement (encaissements). Rule BR-FR-MAP-03.

Changed in:
- `examples/tax-data-report/country-specific-examples/france/PUF_FR_SALES_INVOICE_TDR_CROSSBORDER_B2Bi_DRAFT.xml`
- `examples/tax-data-report/country-specific-examples/france/PUF_FR_PURCHASE_INVOICE_TDR_CROSSBORDER_Bi2B_DRAFT.xml`
- `examples/tax-data-report/country-specific-examples/france/PUF_FR_PURCHASE_INVOICE_TDR_CROSSBORDER_Bi2B_DRAFT - RECTIFICATION.xml`

The examples under `examples/country-specific-examples/france` already used the correct element, so no other file was affected.

## 2. UC-32a / UC-32b used BT-7 with a meter reading date

Both examples declared BT-7 `cbc:TaxPointDate` = meter reading date while their `#ABL#` note states the seller has **not** opted for *TVA sur les débits* (VAT exigible on collection). Two problems:

- The French specification states for BT-7: *"Cette donnée n'est pas utilisée en France. C'est BT-8 qui indique le régime qui est normalement utilisée."*
- A meter reading date is not a valid tax point under the cash-basis regime — the tax point is the payment.

BT-7 removed, BT-8 = `432` (Paid to date) added to `cac:InvoicePeriod`. BT-7 and BT-8 are mutually exclusive (BR-CO-03), so only one is now present. UC-32b had the identical defect and is corrected the same way.

## 3. Root cause — specification gap

`cac:InvoicePeriod` in the PUF Billing specification documented only `StartDate`, `EndDate` and `Description`; `cbc:DescriptionCode` was not documented at all, which is very likely why `cbc:Description` was picked up from the TDR sample.

- `specification/syntax/document-level/InvoicePeriod.adoc` — documents `cbc:DescriptionCode` as the VAT point date code with the UNTDID 2005 subset values and the mutual exclusivity with BT-7.
- `specification/syntax/document-level/TaxPointDate.adoc` — cross-references BT-8.
- `index.html` rebuilt with `asciidoctor -a stylesheet=css/pagero.css -o index.html index.adoc`.

## Validation

All five modified example files re-validated against `xml-schemas/maindoc/Pagero-Universal-Format-Invoice-2.1.xsd` / `Pagero-Universal-Format-CreditNote-2.1.xsd` — all valid.
