### PR TITLE
Add non-EU seller purchase example with dual currency (France TDR)

### DIFF
--- a/examples/tax-data-report/country-specific-examples/france/PUF_FR_PURCHASE_INVOICE_TDR_CROSSBORDER_NonEU_Seller_DualCurrency_DRAFT.xml
+++ b/examples/tax-data-report/country-specific-examples/france/PUF_FR_PURCHASE_INVOICE_TDR_CROSSBORDER_NonEU_Seller_DualCurrency_DRAFT.xml
@@ -30,6 +30,11 @@
             <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:RestrictedInformation</ext:ExtensionURI>
             <ext:ExtensionContent>
                 <puf:PageroExtension>
+                    <!-- Best practice: always send the issuer-created tax report id -> taxReport/taxReportId -->
+                    <puf:RestrictedInformation>
+                        <puf:Key>taxReportId</puf:Key>
+                        <puf:Value>INV-MX-2026-0001</puf:Value>
+                    </puf:RestrictedInformation>
                     <!-- Indication of type of taxreporting (can be INVOICE or RECEIPTTRANSACTION) -->
                     <puf:RestrictedInformation>
                         <puf:Key>entryType</puf:Key>

--- a/examples/tax-data-report/country-specific-examples/france/PUF_FR_PURCHASE_INVOICE_TDR_CROSSBORDER_NonEU_Seller_DualCurrency_DRAFT.xml
+++ b/examples/tax-data-report/country-specific-examples/france/PUF_FR_PURCHASE_INVOICE_TDR_CROSSBORDER_NonEU_Seller_DualCurrency_DRAFT.xml
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Invoice xmlns:cac="urn:pagero:CommonAggregateComponents:1.0"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+    xmlns="urn:pagero:PageroUniversalFormat:Invoice:1.0" xmlns:puf="urn:pagero:ExtensionComponent:1.0" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+
+
+    <!-- Example values only. Cross-border B2B PURCHASE invoice being reported (Bi2B).
+         Buyer in France, seller OUTSIDE the EU (Mexico), invoiced in the seller's own
+         currency (MXN). Generic dual-currency variant of
+         PUF_FR_PURCHASE_INVOICE_TDR_CROSSBORDER_NonEU_Seller_DRAFT.xml: any non-EU
+         seller invoicing in a non-EUR currency requires the same pattern - BT-5
+         (document currency) carries the foreign currency, and BT-6 (tax currency
+         code) is mandatory and set to EUR, with all VAT/monetary amounts also
+         reported in EUR via TaxCurrencyCode-driven extensions.
+
+         Party identification (BR-FR-MAP-16): the seller/buyer legal registration id
+         (cac:PartyLegalEntity/cbc:CompanyID) carries a @schemeID from the AFNOR-approved
+         list for Flux 10, and the value is the party's real registration identifier -
+         no special value construction is required:
+           * France          -> 0002 (SIREN)
+           * EU              -> 0223 (intra-community VAT number)
+           * non-EU          -> 0227
+           * New Caledonia   -> 0228 (RIDET)
+           * French Polynesia -> 0229 (TAHITI)
+         A non-EU seller (this example) is therefore identified with @schemeID="0227"
+         and its own registration number as the value - here a Mexican RFC. -->
+
+    <ext:UBLExtensions>
+        <ext:UBLExtension>
+            <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:RestrictedInformation</ext:ExtensionURI>
+            <ext:ExtensionContent>
+                <puf:PageroExtension>
+                    <!-- Indication of type of taxreporting (can be INVOICE or RECEIPTTRANSACTION) -->
+                    <puf:RestrictedInformation>
+                        <puf:Key>entryType</puf:Key>
+                        <puf:Value>INVOICE</puf:Value>
+                    </puf:RestrictedInformation>
+                    <!-- B2B / B2C classification -->
+                    <puf:RestrictedInformation>
+                        <puf:Key>transactionType</puf:Key>
+                        <puf:Value>B2B</puf:Value>
+                    </puf:RestrictedInformation>
+                    <!-- if a report period needs to be sent -->
+                    <puf:RestrictedInformation>
+                        <puf:Key>reportPeriodStart</puf:Key>
+                        <puf:Value>2026-01-01</puf:Value>
+                    </puf:RestrictedInformation>
+                    <puf:RestrictedInformation>
+                        <puf:Key>reportPeriodEnd</puf:Key>
+                        <puf:Value>2026-01-31</puf:Value>
+                    </puf:RestrictedInformation>
+                </puf:PageroExtension>
+            </ext:ExtensionContent>
+        </ext:UBLExtension>
+    </ext:UBLExtensions>
+
+    <!-- BT-24 Specification identifier -->
+    <cbc:CustomizationID>urn:pagero.com:puf:billing:2.0</cbc:CustomizationID>
+    <!-- BT-23 Business process type. Purchase reporting (EXPENSE). -->
+    <cbc:ProfileID>urn:pagero.com:puf:purchase:1.0</cbc:ProfileID>
+    <!-- BT-1 Invoice Number -->
+    <cbc:ID>INV-MX-2026-0001</cbc:ID>
+    <!-- BT-2 Invoice Issue Date  -->
+    <cbc:IssueDate>2026-01-15</cbc:IssueDate>
+    <!-- BT-9 Due Date -->
+    <cbc:DueDate>2026-02-14</cbc:DueDate>
+    <!-- BT-3 Invoice Type Code, in attribute @name the business process. -->
+    <cbc:InvoiceTypeCode name="B1">380</cbc:InvoiceTypeCode>
+    <!-- BT-5 Invoice Document Currency: seller's own currency (foreign, non-EUR) -->
+    <cbc:DocumentCurrencyCode>MXN</cbc:DocumentCurrencyCode>
+    <!-- BT-6 Tax currency code: mandatory since BT-5 is not EUR -->
+    <cbc:TaxCurrencyCode>EUR</cbc:TaxCurrencyCode>
+
+    <!-- BG-4 Seller (non-EU: Mexico) -->
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Proveedor Industrial de México SA de CV</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:CityName>Monterrey</cbc:CityName>
+                <cac:Country>
+                    <!-- BT-40 Seller address country code. Non-EU country. -->
+                    <cbc:IdentificationCode>MX</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyLegalEntity>
+                <!-- BT-27 Seller Name -->
+                <cbc:RegistrationName>Proveedor Industrial de México SA de CV</cbc:RegistrationName>
+                <!-- BT-30 Seller legal registration identifier.
+                     Non-EU seller -> @schemeID 0227, value is the seller's own
+                     registration number (here a Mexican RFC), passed through as-is. -->
+                <cbc:CompanyID schemeID="0227">PIM010101AB1</cbc:CompanyID>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <!-- BG-7 Buyer (France) -->
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PostalAddress>
+                <cac:Country>
+                    <!-- BT-55 Buyer address country code -->
+                    <cbc:IdentificationCode>FR</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <!-- BT-48 Buyer TAX Number -->
+                <cbc:CompanyID>FR00323456789</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <!-- BT-44 Buyer Name -->
+                <cbc:RegistrationName>Buyer Company Name</cbc:RegistrationName>
+                <!-- BT-47 Buyer legal registration identifier. France -> @schemeID 0002 (SIREN). -->
+                <cbc:CompanyID schemeID="0002">323456789</cbc:CompanyID>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+
+    <!-- Tax exchange rate: MXN -> EUR -->
+    <cac:TaxExchangeRate>
+        <cbc:SourceCurrencyCode>MXN</cbc:SourceCurrencyCode>
+        <cbc:TargetCurrencyCode>EUR</cbc:TargetCurrencyCode>
+        <cbc:CalculationRate>0.0480</cbc:CalculationRate>
+        <cbc:MathematicOperatorCode>Multiply</cbc:MathematicOperatorCode>
+    </cac:TaxExchangeRate>
+
+    <cac:TaxTotal>
+        <!-- BT-110 Invoice total TAX amount in document currency (MXN) -->
+        <cbc:TaxAmount currencyID="MXN">8000.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <ext:UBLExtensions>
+                <ext:UBLExtension>
+                    <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:TaxSubtotalExtension</ext:ExtensionURI>
+                    <ext:ExtensionContent>
+                        <puf:PageroExtension>
+                            <puf:TaxSubtotalExtension>
+                                <!-- Tax amounts converted to EUR (tax/accounting currency) -->
+                                <puf:TaxCurrencyTaxableAmount currencyID="EUR">1920.00</puf:TaxCurrencyTaxableAmount>
+                                <puf:TaxCurrencyTaxAmount currencyID="EUR">384.00</puf:TaxCurrencyTaxAmount>
+                            </puf:TaxSubtotalExtension>
+                        </puf:PageroExtension>
+                    </ext:ExtensionContent>
+                </ext:UBLExtension>
+            </ext:UBLExtensions>
+            <!-- BT-116 Sum of all taxable amounts subject to a specific TAX category code and TAX category rate (MXN) -->
+            <cbc:TaxableAmount currencyID="MXN">40000.00</cbc:TaxableAmount>
+            <!-- BT-117 The total TAX amount for a given TAX category (MXN) -->
+            <cbc:TaxAmount currencyID="MXN">8000.00</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <!-- BT-118 TAX category code -->
+                <cbc:ID>S</cbc:ID>
+                <!-- BT-119 TAX category rate -->
+                <cbc:Percent>20</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <!-- BT-111 Invoice total TAX amount in tax/accounting currency (EUR) -->
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">384.00</cbc:TaxAmount>
+    </cac:TaxTotal>
+
+    <cac:LegalMonetaryTotal>
+        <ext:UBLExtensions>
+            <ext:UBLExtension>
+                <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:LegalMonetaryTotalExtension</ext:ExtensionURI>
+                <ext:ExtensionContent>
+                    <puf:PageroExtension>
+                        <puf:LegalMonetaryTotalExtension>
+                            <!-- Invoice total amount without TAX in tax currency (EUR) -->
+                            <puf:TaxCurrencyTaxExclusiveAmount currencyID="EUR">1920.00</puf:TaxCurrencyTaxExclusiveAmount>
+                            <!-- Invoice total amount with TAX in tax currency (EUR) -->
+                            <puf:TaxCurrencyTaxInclusiveAmount currencyID="EUR">2304.00</puf:TaxCurrencyTaxInclusiveAmount>
+                        </puf:LegalMonetaryTotalExtension>
+                    </puf:PageroExtension>
+                </ext:ExtensionContent>
+            </ext:UBLExtension>
+        </ext:UBLExtensions>
+        <!-- BT-109 Invoice total amount without TAX (MXN) -->
+        <cbc:TaxExclusiveAmount currencyID="MXN">40000.00</cbc:TaxExclusiveAmount>
+        <!-- BT-112 Invoice total amount with TAX (MXN) -->
+        <cbc:TaxInclusiveAmount currencyID="MXN">48000.00</cbc:TaxInclusiveAmount>
+        <!-- BT-115 Amount due for payment (MXN) -->
+        <cbc:PayableAmount currencyID="MXN">48000.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <!-- BT-126 Line ID -->
+        <cbc:ID>1</cbc:ID>
+        <!-- BT-129 Invoiced Quantity. BT-130 unit of measure in attribute unitCode -->
+        <cbc:InvoicedQuantity unitCode="NAR">100</cbc:InvoicedQuantity>
+        <!-- BT-131 Line extension amount. Line net amount (MXN) -->
+        <cbc:LineExtensionAmount currencyID="MXN">40000.00</cbc:LineExtensionAmount>
+        <cac:Item>
+            <!-- BT-153 Item name -->
+            <cbc:Name>Livraison de composants industriels</cbc:Name>
+            <!-- BG-30 LINE TAX INFORMATION -->
+            <cac:ClassifiedTaxCategory>
+                <!-- BT-151 Invoiced item TAX category code -->
+                <cbc:ID>S</cbc:ID>
+                <!-- BT-152 Invoiced item TAX rate -->
+                <cbc:Percent>20</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <!-- BG-29 PRICE DETAILS -->
+        <cac:Price>
+            <!-- BT-146 Item net price (MXN) -->
+            <cbc:PriceAmount currencyID="MXN">400.00</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>

--- a/examples/tax-data-report/country-specific-examples/france/README.md
+++ b/examples/tax-data-report/country-specific-examples/france/README.md
@@ -10,7 +10,8 @@ Example files for French invoice e-reporting (Flux 10.1). These use the standard
 |------|-----------|------------|-------------|
 | `PUF_FR_SALES_INVOICE_TDR_CROSSBORDER_B2Bi_DRAFT.xml` | Sales (B2Bi) | INVOICE | Draft — Cross-border B2B sales invoice reporting. French seller, Italian buyer. Services invoice (S1). |
 | `PUF_FR_SALES_INVOICE_TDR_POS_TRANSACTIONS_DRAFT.xml` | Sales (B2C) | RECEIPTTRANSACTION | Draft — B2C POS receipt transaction reporting. Aggregated daily transactions with TLB1 (goods) and TPS1 (services) category codes. |
-| `PUF_FR_PURCHASE_INVOICE_TDR_CROSSBORDER_Bi2B_DRAFT.xml` | Purchase (Bi2B) | INVOICE | Draft — Cross-border B2B purchase invoice reporting. French buyer, German seller. ProfileID = `urn:pagero.com:puf:purchase:1.0`. |
+| `PUF_FR_PURCHASE_INVOICE_TDR_CROSSBORDER_Bi2B_DRAFT.xml` | Purchase (Bi2B) | INVOICE | Draft — Cross-border B2B purchase invoice reporting. French buyer, German (EU) seller. ProfileID = `urn:pagero.com:puf:purchase:1.0`. Seller identified with EU VAT (schemeID `0223`). |
+| `PUF_FR_PURCHASE_INVOICE_TDR_CROSSBORDER_NonEU_Seller_DualCurrency_DRAFT.xml` | Purchase (Bi2B) | INVOICE | Draft — Cross-border B2B purchase invoice reporting with a **non-EU seller** (Mexico), invoicing in its own currency. Demonstrates BR-FR-MAP-16 party identification for a non-EU party (schemeID `0227`, value passed through as-is) together with dual currency: BT-5 `DocumentCurrencyCode` = MXN, BT-6 `TaxCurrencyCode` = EUR (mandatory since BT-5 isn't EUR). VAT/monetary amounts reported in both MXN (document currency) and EUR (tax currency) via `TaxSubtotalExtension`/`LegalMonetaryTotalExtension`. Validated end-to-end through `PUF_as_TDR_Ext_to_Int.xslt` → `FE_e-reporting_France_Int_to_Ext.xsl` → `ereporting.xsd` + the AIFE-PPF Flux10 Schematron. |
 | `PUF_FR_PURCHASE_INVOICE_TDR_CROSSBORDER_Bi2B_DRAFT - RECTIFICATION.xml` | Purchase (Bi2B) | INVOICE | Draft — Rectification/replace-period scenario for the cross-border B2B purchase report. `transmissionType = RECTIFICATION` with `taxReportId` (id of the replacing report) and `referencedReportId` (id of the aggregated report being replaced). Report period (`reportPeriodStart`/`reportPeriodEnd`) MUST match the report being replaced, and all documents belonging to that period must be resent. |
 | `PUF_France_UC43_IntraCommunitySupply_InvoiceReport.xml` | Sales (B2Bi) | INVOICE | UC43 — Intra-community goods supply from France to Germany. VAT category K with `VATEX-EU-IC`. `#BAR#B2BINT` treatment type. Buyer identified with EU VAT number (schemeID `0223`). |
 | `PUF_France_UC44_DROM_GuadeloupeToGuyane_InvoiceReport.xml` | Sales (B2Bi) | INVOICE | UC44 — DROM transaction from Guadeloupe (Group 1) to French Guiana (Group 2). Demonstrates BR-FR-MAP-14 country code mapping (GP → FR, GF stays GF). VAT category G with `VATEX-EU-G`. |
@@ -53,7 +54,21 @@ For B2C and transaction reporting, each invoice line may include a category code
 
 - **Flux 10.1**: Invoice-level e-reporting for international B2B sales, international B2B acquisitions (excl. goods imports), and B2C transactions.
 - **BAR treatment type**: `#BAR#B2BINT` signals international B2B e-reporting (BR-FR-20).
-- **Party identification (BR-FR-MAP-16)**: France = SIREN (`0002`), EU = VAT number (`0223`), non-EU = country + name (`0227`), New Caledonia = RIDET (`0228`), French Polynesia = TAHITI (`0229`).
+- **Party identification (BR-FR-MAP-16)**: the seller/buyer legal registration identifier is carried in `cac:PartyLegalEntity/cbc:CompanyID` with a `@schemeID` from the AFNOR-approved list below. The **value is the party's own registration identifier, passed through as-is** — no special value construction (e.g. country + name) is required. Provide an approved `@schemeID` and the mapping carries it through to the report. All of the approved AFNOR schemes are allowed in PUF:
+
+  | schemeID | Party identifier | Typical use |
+  |----------|------------------|-------------|
+  | `0002` | SIREN | French company (9 digits) |
+  | `0009` | SIRET | French establishment (14 digits) |
+  | `0088` | GLN | GS1 Global Location Number |
+  | `0223` | Intra-community VAT number | EU party |
+  | `0226` | French natural person id | Individual (B2C) |
+  | `0227` | Non-EU identifier | Party established outside the EU |
+  | `0228` | RIDET | New Caledonia |
+  | `0229` | TAHITI | French Polynesia |
+  | `0231` | Single-taxable-company id | French VAT group / single taxable person |
+  | `0238` | PDP matricule | Accredited platform (PA/PDP) |
+
 - **Country code mapping (BR-FR-MAP-14)**: Overseas territory codes (GP, MQ, RE) → `FR` in flux; Guyane (GF) and Mayotte (YT) stay as-is in Flux 10.1.
 - **Currency**: For B2B, any valid currency; if not EUR, BT-6 (tax currency code) is mandatory. For B2C/transaction, must be EUR.
 - **Phased rollout (G6.15)**: Header-level data from Sept 2026; line-level data + allowances/charges from Sept 2027.


### PR DESCRIPTION
## Summary
- Adds `PUF_FR_PURCHASE_INVOICE_TDR_CROSSBORDER_NonEU_Seller_DualCurrency_DRAFT.xml`: a cross-border B2B purchase e-reporting example with a Mexican seller invoicing in MXN, demonstrating mandatory BT-6 `TaxCurrencyCode` (EUR) alongside non-EU party identification (schemeID `0227`).
- Updates the France TDR README to document the new example.

## Test plan
- [x] Validated against the PUF Invoice XSD
- [x] Ran through `PUF_as_TDR_Ext_to_Int.xslt` → `FE_e-reporting_France_Int_to_Ext.xsl` → validated against `ereporting.xsd` and the AIFE-PPF Flux10 Schematron: 0 failed assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)