### PR TITLE
Document archive-only credit notes for France and add B2CINT

### DIFF
--- a/examples/country-specific-examples/france/PUF_France_ARCHIVEONLY_CreditNote.xml
+++ b/examples/country-specific-examples/france/PUF_France_ARCHIVEONLY_CreditNote.xml
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    PUF France Archive-Only Credit Note Example (#BAR#ARCHIVEONLY)
+
+    Business Scenario:
+    - Invoice FR-INV-2026-050 was given the lifecycle status "Rejetee" and therefore never
+      reached the buyer.
+    - The seller must reverse it in their accounts. They cannot raise the reversal purely
+      internally, so they submit the internal credit note (AVOIR interne) to their platform
+      for archiving only.
+    - Full reversal of the rejected invoice: 200.00 net, 40.00 VAT, 240.00 gross.
+
+    Treatment type:
+    - #BAR#ARCHIVEONLY declares that the document must not be subject to e-invoicing
+      processing: no flux 1 to the PPF and no transmission to the recipient
+      (AFNOR XP Z12-012 v1.4, rule BR-FR-20). Pagero Online will neither clear nor
+      deliver it, so it never reaches the buyer.
+    - BG-3 (cac:BillingReference) references the reversed invoice, which is what
+      XP Z12-014 v1.4 section 2.2 scopes the behaviour to.
+
+    French Mandatory Elements:
+    - BT-23: Business process type (B1 = goods invoice / credit note)
+    - BT-34, BT-49: Seller and buyer electronic addresses (schemeID 0225)
+    - French text codes (BT-21/BT-22): #REG#, #ABL#, #AAI#, #PMD#, #PMT#, #AAB#, #BAR#
+    - SIRET identifiers, French address format
+-->
+<CreditNote xmlns="urn:pagero:PageroUniversalFormat:CreditNote:1.0" xmlns:cac="urn:pagero:CommonAggregateComponents:1.0" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:puf="urn:pagero:ExtensionComponent:1.0" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+
+    <cbc:CustomizationID>urn:pagero.com:puf:billing:2.0</cbc:CustomizationID>
+    <cbc:ProfileID>urn:pagero.com:puf:billing:1.0</cbc:ProfileID>
+    <!-- BT-1 Credit Note Number -->
+    <cbc:ID>FR-CN-2026-050R</cbc:ID>
+    <!-- BT-2 Credit Note Issue Date -->
+    <cbc:IssueDate>2026-09-04</cbc:IssueDate>
+    <!-- BT-3 Credit Note Type Code - 381: Credit note -->
+    <!-- @name attribute contains business process type: B1 = goods invoice / credit note -->
+    <cbc:CreditNoteTypeCode name="B1">381</cbc:CreditNoteTypeCode>
+
+    <!-- Reason for the reversal.
+         Unprefixed notes must not follow the #BAR# note: BR-FR-20 concatenates all notes
+         without a separator and reads everything after "#BAR#" up to the next "#", so a
+         plain note placed after it is absorbed into the treatment-type value. -->
+    <cbc:Note>Avoir interne d'annulation de la facture FR-INV-2026-050 rejetée - non transmis au destinataire</cbc:Note>
+
+    <!-- BT-21/BT-22: French text codes -->
+    <!-- #REG#: Company legal form and share capital -->
+    <cbc:Note>#REG#SARL au capital de 100000.00 EUR</cbc:Note>
+    <!-- #ABL#: Legal information - Trade register -->
+    <cbc:Note>#ABL#RCS Lyon B 987 654 321</cbc:Note>
+    <!-- #AAI#: APE code (business activity classification) -->
+    <cbc:Note>#AAI#APE 4651Z - Commerce de gros d'ordinateurs</cbc:Note>
+    <!-- #PMD#: Late payment penalties -->
+    <cbc:Note>#PMD#En cas de retard de paiement, application des pénalités à un taux égal au taux d'intérêt appliqué par la BCE majoré de 10 points de pourcentage</cbc:Note>
+    <!-- #PMT#: Fixed indemnity for collection costs -->
+    <cbc:Note>#PMT#Indemnité forfaitaire pour frais de recouvrement en cas de retard de paiement : 40 EUR</cbc:Note>
+    <!-- #AAB#: Early payment discount mention -->
+    <cbc:Note>#AAB#Pas d'escompte pour paiement anticipé</cbc:Note>
+    <!-- #BAR#: Treatment type qualification - ARCHIVEONLY.
+         Internal credit note cancelling a Rejetee invoice. Not cleared, not transmitted. -->
+    <cbc:Note>#BAR#ARCHIVEONLY</cbc:Note>
+
+    <!-- BT-5 Credit Note Document Currency -->
+    <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+
+    <!-- BG-3 / BT-25 Preceding invoice reference: the rejected invoice being reversed -->
+    <cac:BillingReference>
+        <cac:InvoiceDocumentReference>
+            <cbc:ID>FR-INV-2026-050</cbc:ID>
+            <cbc:IssueDate>2026-09-01</cbc:IssueDate>
+        </cac:InvoiceDocumentReference>
+    </cac:BillingReference>
+
+    <!-- BG-4 Seller Information -->
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <!-- BT-34 Seller electronic address (schemeID 0225 = French e-invoicing annuaire address) -->
+            <cbc:EndpointID schemeID="0225">987654321</cbc:EndpointID>
+            <!-- BT-29 SIRET identifier -->
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="0009">98765432100012</cbc:ID>
+            </cac:PartyIdentification>
+            <!-- BT-28 Seller Trading Name -->
+            <cac:PartyName>
+                <cbc:Name>TechDistrib France</cbc:Name>
+            </cac:PartyName>
+            <!-- BG-5 Seller Address -->
+            <cac:PostalAddress>
+                <cbc:StreetName>12 Rue de la République</cbc:StreetName>
+                <cbc:CityName>Lyon</cbc:CityName>
+                <cbc:PostalZone>69002</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>FR</cbc:IdentificationCode>
+                    <cbc:Name>France</cbc:Name>
+                </cac:Country>
+            </cac:PostalAddress>
+            <!-- BT-31 Seller VAT identifier -->
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>FR12987654321</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <!-- BT-27 Seller legal registration identifier (SIREN) -->
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>TechDistrib France SARL</cbc:RegistrationName>
+                <cbc:CompanyID schemeID="0002">987654321</cbc:CompanyID>
+            </cac:PartyLegalEntity>
+            <!-- BG-6 Seller Contact -->
+            <cac:Contact>
+                <cbc:Name>Service Comptabilité</cbc:Name>
+                <cbc:Telephone>+33 4 72 00 00 00</cbc:Telephone>
+                <cbc:ElectronicMail>comptabilite@techdistrib.fr</cbc:ElectronicMail>
+            </cac:Contact>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+
+    <!-- BG-7 Buyer Information.
+         The buyer never received the rejected invoice and will not receive this credit note.
+         The party is still stated because the document is a credit note in the seller's accounts. -->
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <!-- BT-49 Buyer electronic address (schemeID 0225) -->
+            <cbc:EndpointID schemeID="0225">123456789</cbc:EndpointID>
+            <!-- BT-46 Buyer identifier -->
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="0009">12345678900034</cbc:ID>
+            </cac:PartyIdentification>
+            <!-- BT-45 Buyer Trading Name -->
+            <cac:PartyName>
+                <cbc:Name>Entreprise Client France</cbc:Name>
+            </cac:PartyName>
+            <!-- BG-8 Buyer Address -->
+            <cac:PostalAddress>
+                <cbc:StreetName>45 Avenue de la Liberté</cbc:StreetName>
+                <cbc:CityName>Paris</cbc:CityName>
+                <cbc:PostalZone>75008</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>FR</cbc:IdentificationCode>
+                    <cbc:Name>France</cbc:Name>
+                </cac:Country>
+            </cac:PostalAddress>
+            <!-- BT-48 Buyer VAT identifier -->
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>FR34123456789</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <!-- BT-44 Buyer legal registration identifier (SIREN) -->
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Entreprise Client France SA</cbc:RegistrationName>
+                <cbc:CompanyID schemeID="0002">123456789</cbc:CompanyID>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+
+    <!-- BG-23 VAT Breakdown -->
+    <cac:TaxTotal>
+        <!-- BT-110 Credit Note total VAT amount -->
+        <cbc:TaxAmount currencyID="EUR">40.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <!-- BT-116 VAT category taxable amount -->
+            <cbc:TaxableAmount currencyID="EUR">200.00</cbc:TaxableAmount>
+            <!-- BT-117 VAT category tax amount -->
+            <cbc:TaxAmount currencyID="EUR">40.00</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <!-- BT-118 VAT category code - S: Standard rate -->
+                <cbc:ID>S</cbc:ID>
+                <!-- BT-119 VAT rate - 20% standard rate in France -->
+                <cbc:Percent>20.00</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+
+    <!-- BG-22 Document Totals -->
+    <cac:LegalMonetaryTotal>
+        <!-- BT-106 Sum of Credit Note line net amount -->
+        <cbc:LineExtensionAmount currencyID="EUR">200.00</cbc:LineExtensionAmount>
+        <!-- BT-109 Credit Note total amount without VAT -->
+        <cbc:TaxExclusiveAmount currencyID="EUR">200.00</cbc:TaxExclusiveAmount>
+        <!-- BT-112 Credit Note total amount with VAT -->
+        <cbc:TaxInclusiveAmount currencyID="EUR">240.00</cbc:TaxInclusiveAmount>
+        <!-- BT-115 Amount due for payment -->
+        <cbc:PayableAmount currencyID="EUR">240.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+
+    <!-- BG-25 Credit Note Line - full reversal of the rejected invoice line -->
+    <cac:CreditNoteLine>
+        <!-- BT-126 Credit Note line identifier -->
+        <cbc:ID>1</cbc:ID>
+        <!-- BT-129 Credited quantity -->
+        <cbc:CreditedQuantity unitCode="H87">2</cbc:CreditedQuantity>
+        <!-- BT-131 Credit Note line net amount -->
+        <cbc:LineExtensionAmount currencyID="EUR">200.00</cbc:LineExtensionAmount>
+        <!-- BG-31 Item Information -->
+        <cac:Item>
+            <!-- BT-154 Item description -->
+            <cbc:Description>Annulation comptable de la ligne facturée sur la facture rejetée FR-INV-2026-050</cbc:Description>
+            <!-- BT-153 Item name -->
+            <cbc:Name>Ordinateur portable professionnel</cbc:Name>
+            <!-- BG-30 Line VAT Information -->
+            <cac:ClassifiedTaxCategory>
+                <!-- BT-151 Credited item VAT category code -->
+                <cbc:ID>S</cbc:ID>
+                <!-- BT-152 Credited item VAT rate -->
+                <cbc:Percent>20.00</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <!-- BG-29 Price Details -->
+        <cac:Price>
+            <!-- BT-146 Item net price -->
+            <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+            <!-- BT-149 Item price base quantity -->
+            <cbc:BaseQuantity unitCode="H87">1</cbc:BaseQuantity>
+        </cac:Price>
+    </cac:CreditNoteLine>
+
+</CreditNote>

--- a/examples/country-specific-examples/france/README.md
+++ b/examples/country-specific-examples/france/README.md
@@ -63,11 +63,29 @@ Demonstrates:
 
 ---
 
+#### 3. PUF_France_ARCHIVEONLY_CreditNote.xml
+
+**Archive-Only Internal Credit Note (`#BAR#ARCHIVEONLY`)**
+
+Demonstrates:
+
+- Reversal of an invoice that carried the lifecycle status *Rejetee* and therefore never reached the buyer
+- `#BAR#ARCHIVEONLY` treatment type per AFNOR XP Z12-012 rule BR-FR-20
+- BG-3 reference to the rejected invoice, as scoped by XP Z12-014 section 2.2
+- Unprefixed notes placed before the `#BAR#` note, which BR-FR-20 requires in UBL
+
+**Key Features:**
+
+- Document type: 381 with name="B1"
+- Non-regulated. Pagero Online neither clears nor delivers the document, so it never reaches the buyer
+
+---
+
 ### Chorus Pro B2G Qualification Examples
 
 These examples are PUF source counterparts of the eight invoice fixtures in the AIFE Chorus Pro qualification kit. Each file carries the AIFE qualification `0225` endpoints directly; those values are test data and are not a general construction rule for French electronic addresses.
 
-For France, `#BAR#` is mandatory in every non-B2G scenario (`B2B`, `B2BINT`, `B2C`, `OUTOFSCOPE`, or `ARCHIVEONLY`). It is not required for B2G. These examples therefore omit `#BAR#`, carry `#ADN#B2G`, and set `puf:ComplianceActivatedIndicator` to `true`.
+For France, `#BAR#` is mandatory in every non-B2G scenario (`B2B`, `B2BINT`, `B2C`, `B2CINT`, `OUTOFSCOPE`, or `ARCHIVEONLY`). It is not required for B2G. These examples therefore omit `#BAR#`, carry `#ADN#B2G`, and set `puf:ComplianceActivatedIndicator` to `true`.
 
 | AIFE scenario | PUF example | Distinguishing coverage |
 |---|---|---|
@@ -992,7 +1010,7 @@ Invoice e-reporting examples (UC43, UC44) are located in the **tax-data-report**
 | **#AAI#** | General information | General elements typically found at the bottom of paper invoice pages | *(free text)* |
 | **#PMD#** | Late payment penalties | Payment terms regarding late payment penalties | *(free text)* |
 | **#PMT#** | Collection costs (€40) | Fixed €40 indemnity for collection costs in case of late payment | *(free text)* |
-| **#BAR#** | Treatment type qualification | Mandatory for every non-B2G France scenario. Only ONE BAR note per invoice. Not required for B2G. | `B2B`, `B2BINT`, `B2C`, `OUTOFSCOPE`, or `ARCHIVEONLY` |
+| **#BAR#** | Treatment type qualification | Mandatory for every non-B2G France scenario. Only ONE BAR note per invoice. Not required for B2G. | `B2B`, `B2BINT`, `B2C`, `B2CINT`, `OUTOFSCOPE`, or `ARCHIVEONLY` |
 | **#AAB#** | Early payment discount | Statement whether customer can apply a discount for early payment. Does NOT correspond to the discount amount itself. | *(free text)* |
 | **#ABU#** | Contract clause | Contractual reservation clause / Retenue de garantie | *(free text)* |
 | **#ACC#** | Subrogation factoring clause | Factoring arrangement details and subrogation clauses | *(free text)* |

--- a/index.html
+++ b/index.html
@@ -712,14 +712,15 @@ table.CodeRay td.code{padding:0 0 0 .75em}
 <li><a href="#_invoice_type_code_and_business_process_type">5.4.2. Invoice Type Code and Business Process Type</a></li>
 <li><a href="#_french_text_codes_note_elements">5.4.3. French Text Codes (Note Elements)</a></li>
 <li><a href="#_compliance_and_regulated_status_type_de_processus_métier">5.4.4. Compliance and Regulated Status (Type de processus métier)</a></li>
-<li><a href="#_credit_note_for_global_discount_code_262">5.4.5. Credit note for global discount (Code 262)</a></li>
-<li><a href="#_sub_lines_and_line_groupings">5.4.6. Sub-lines and Line Groupings</a></li>
-<li><a href="#_self_billing_indicator_2">5.4.7. Self-Billing Indicator</a></li>
-<li><a href="#_business_and_vat_identification">5.4.8. Business and VAT Identification</a></li>
-<li><a href="#_mandate_scenarios_agent_parties">5.4.9. Mandate Scenarios - Agent Parties</a></li>
-<li><a href="#_service_code">5.4.10. Service code</a></li>
-<li><a href="#_b2g_public_sector_chorus_pro">5.4.11. B2G / public sector (Chorus Pro)</a></li>
-<li><a href="#_legal_commitments">5.4.12. Legal commitments</a></li>
+<li><a href="#_archive_only_credit_notes_archiveonly">5.4.5. Archive-only credit notes (ARCHIVEONLY)</a></li>
+<li><a href="#_credit_note_for_global_discount_code_262">5.4.6. Credit note for global discount (Code 262)</a></li>
+<li><a href="#_sub_lines_and_line_groupings">5.4.7. Sub-lines and Line Groupings</a></li>
+<li><a href="#_self_billing_indicator_2">5.4.8. Self-Billing Indicator</a></li>
+<li><a href="#_business_and_vat_identification">5.4.9. Business and VAT Identification</a></li>
+<li><a href="#_mandate_scenarios_agent_parties">5.4.10. Mandate Scenarios - Agent Parties</a></li>
+<li><a href="#_service_code">5.4.11. Service code</a></li>
+<li><a href="#_b2g_public_sector_chorus_pro">5.4.12. B2G / public sector (Chorus Pro)</a></li>
+<li><a href="#_legal_commitments">5.4.13. Legal commitments</a></li>
 </ul>
 </li>
 <li><a href="#_greece">5.5. Greece</a>
@@ -7662,6 +7663,20 @@ When set to <code>true</code>, the document must not be sent to a clearance auth
 </tr>
 </table>
 </div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>For France, <code>puf:ComplianceActivatedIndicator</code> takes precedence over the mandatory <code><mark>BAR</mark></code> treatment-type note. A <code>#BAR#ARCHIVEONLY</code> note additionally suppresses clearance and delivery; see <a href="#_france">France</a> for what Pagero Online does with that document.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
 <div class="paragraph">
 <p>See example below as well as the URI to be used for this extension.</p>
 </div>
@@ -7729,6 +7744,22 @@ Indicates that the document should be processed without standard Pagero routing 
 </tr>
 </tbody>
 </table>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>The two values differ in whether the recipient can see the document. With <code>PROCESS_WITHOUT_DELIVERY</code> the
+document is still routed, so a recipient who is also a Pagero customer will see it even though no file is
+delivered. <code>PROCESS_WITHOUT_ROUTING</code> keeps it with the issuing customer alone.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
 <div class="paragraph">
 <p>See example below as well as the URI to be used for this extension.</p>
 </div>
@@ -12301,7 +12332,7 @@ See <a href="https://pagero.github.io/puf-code-lists/#_tax_category_codes_croati
 <td class="tableblock halign-left valign-top"><p class="tableblock"><mark>BAR</mark></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Treatment type qualification</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Type of treatment expected for the invoice</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>One of:</strong> <code>B2B</code>, <code>B2BINT</code>, <code>B2C</code>, <code>OUTOFSCOPE</code>, <code>ARCHIVEONLY</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>One of:</strong> <code>B2B</code>, <code>B2BINT</code>, <code>B2C</code>, <code>B2CINT</code>, <code>OUTOFSCOPE</code>, <code>ARCHIVEONLY</code></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><mark>BLU</mark></p></td>
@@ -12362,7 +12393,7 @@ See <a href="https://pagero.github.io/puf-code-lists/#_tax_category_codes_croati
 <p>The <mark>PMT</mark> fixed indemnity amount is legally set at €40.00 per Article L441-10 of the French Commercial Code</p>
 </li>
 <li>
-<p><mark>BAR</mark> is mandatory for every non-B2G France scenario and must contain exactly ONE of the specified values: <code>B2B</code> (e-invoicing), <code>B2BINT</code> (B2B international e-reporting), <code>B2C</code> (B2C e-reporting), <code>OUTOFSCOPE</code> (outside reform scope), or <code>ARCHIVEONLY</code> (internal credit note - no transmission)</p>
+<p><mark>BAR</mark> is mandatory for every non-B2G France scenario and must contain exactly ONE of the specified values: <code>B2B</code> (e-invoicing), <code>B2BINT</code> (B2B international e-reporting), <code>B2C</code> (B2C e-reporting), <code>B2CINT</code> (B2C international e-reporting), <code>OUTOFSCOPE</code> (outside reform scope), or <code>ARCHIVEONLY</code> (internal credit note, see <a href="#_archive_only_credit_notes_archiveonly">Archive-only credit notes</a>).</p>
 </li>
 <li>
 <p><mark>BAR</mark> is not required for B2G. B2G examples use <code>#ADN#B2G</code> and should provide <code>puf:ComplianceActivatedIndicator</code> = <code>true</code></p>
@@ -12455,7 +12486,7 @@ These text codes apply to both Invoice and CreditNote document types.
 </dd>
 <dt class="hdlist1"><code><mark>BAR</mark></code> treatment-type note (non-B2G fallback)</dt>
 <dd>
-<p>For non-B2G documents, when the explicit indicator is absent, Pagero Online derives the status from the mandatory <code><mark>BAR</mark></code> note (see <a href="#_french_text_codes_note_elements">French Text Codes</a>): <code>#BAR#B2B</code> is treated as <strong>REGULATED</strong>; every other treatment type (<code>B2BINT</code>, <code>B2C</code>, <code>OUTOFSCOPE</code>, <code>ARCHIVEONLY</code>) is treated as <strong>NON_REGULATED</strong>.</p>
+<p>For non-B2G documents, when the explicit indicator is absent, Pagero Online derives the status from the mandatory <code><mark>BAR</mark></code> note (see <a href="#_french_text_codes_note_elements">French Text Codes</a>): <code>#BAR#B2B</code> is treated as <strong>REGULATED</strong>; every other treatment type (<code>B2BINT</code>, <code>B2C</code>, <code>B2CINT</code>, <code>OUTOFSCOPE</code>, <code>ARCHIVEONLY</code>) is treated as <strong>NON_REGULATED</strong>.</p>
 </dd>
 <dt class="hdlist1">B2G classification</dt>
 <dd>
@@ -12503,7 +12534,41 @@ These text codes apply to both Invoice and CreditNote document types.
 </div>
 </div>
 <div class="sect3">
-<h4 id="_credit_note_for_global_discount_code_262"><a class="anchor" href="#_credit_note_for_global_discount_code_262"></a><a class="link" href="#_credit_note_for_global_discount_code_262">5.4.5. Credit note for global discount (Code 262)</a></h4>
+<h4 id="_archive_only_credit_notes_archiveonly"><a class="anchor" href="#_archive_only_credit_notes_archiveonly"></a><a class="link" href="#_archive_only_credit_notes_archiveonly">5.4.5. Archive-only credit notes (ARCHIVEONLY)</a></h4>
+<div class="paragraph">
+<p><code>#BAR#ARCHIVEONLY</code> marks an <strong>internal credit note</strong> (AVOIR interne) reversing an invoice that was
+<strong>Rejetée</strong> or <strong>Refusée</strong>, submitted for archiving only. Per AFNOR XP Z12-012 rule BR-FR-20 such a
+document must not be subject to e-invoicing processing: no flux 1 and no transmission to the recipient.
+Pagero Online will neither clear it nor deliver it, so it never reaches the buyer.</p>
+</div>
+<div class="paragraph">
+<p>Send it as a credit note and reference the reversed invoice in BG-3, which is what XP Z12-014 §2.2
+scopes the behaviour to. Do not add <code>puf:ExternalDeliveryType</code>; it is not needed for this case.</p>
+</div>
+<div class="paragraph">
+<p><strong>Example — archive-only credit note</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;CreditNote&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+    <span class="tag">&lt;cbc:CreditNoteTypeCode</span> <span class="attribute-name">name</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">B1</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>381<span class="tag">&lt;/cbc:CreditNoteTypeCode&gt;</span>
+    <span class="tag">&lt;cbc:Note&gt;</span>#BAR#ARCHIVEONLY<span class="tag">&lt;/cbc:Note&gt;</span>
+
+    <span class="comment">&lt;!-- BG-3 reference to the reversed invoice --&gt;</span>
+    <span class="tag">&lt;cac:BillingReference&gt;</span>
+        <span class="tag">&lt;cac:InvoiceDocumentReference&gt;</span>
+            <span class="tag">&lt;cbc:ID&gt;</span>INV-2026-000123<span class="tag">&lt;/cbc:ID&gt;</span>
+            <span class="tag">&lt;cbc:IssueDate&gt;</span>2026-09-01<span class="tag">&lt;/cbc:IssueDate&gt;</span>
+        <span class="tag">&lt;/cac:InvoiceDocumentReference&gt;</span>
+    <span class="tag">&lt;/cac:BillingReference&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+<span class="tag">&lt;/CreditNote&gt;</span></code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_credit_note_for_global_discount_code_262"><a class="anchor" href="#_credit_note_for_global_discount_code_262"></a><a class="link" href="#_credit_note_for_global_discount_code_262">5.4.6. Credit note for global discount (Code 262)</a></h4>
 <div class="paragraph">
 <p>Invoice type code <code>262</code> ("Avoir pour Remise Globale") is used for credit notes
 issued against one or more previously sent invoices to apply a global
@@ -12561,7 +12626,7 @@ BT-12 / BT-73 remain in their normal locations.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_sub_lines_and_line_groupings"><a class="anchor" href="#_sub_lines_and_line_groupings"></a><a class="link" href="#_sub_lines_and_line_groupings">5.4.6. Sub-lines and Line Groupings</a></h4>
+<h4 id="_sub_lines_and_line_groupings"><a class="anchor" href="#_sub_lines_and_line_groupings"></a><a class="link" href="#_sub_lines_and_line_groupings">5.4.7. Sub-lines and Line Groupings</a></h4>
 <div class="paragraph">
 <p>France (EXTENDED-CTC-FR profile) supports hierarchical invoice lines - sub-lines and line groupings - for composite articles (kits, packs), multi-VAT-rate products, and parent lines with supplements. The lines stay flat; the hierarchy is carried by the generic <a href="#line-sublines">Sub-lines extension</a> (<code>puf:RowType</code> + <code>puf:ParentLineID</code>) together with the native <code>cac:Item/cbc:PackQuantity</code>.</p>
 </div>
@@ -12704,7 +12769,7 @@ Reference examples are available under <code>examples/country-specific-examples/
 </div>
 </div>
 <div class="sect3">
-<h4 id="_self_billing_indicator_2"><a class="anchor" href="#_self_billing_indicator_2"></a><a class="link" href="#_self_billing_indicator_2">5.4.7. Self-Billing Indicator</a></h4>
+<h4 id="_self_billing_indicator_2"><a class="anchor" href="#_self_billing_indicator_2"></a><a class="link" href="#_self_billing_indicator_2">5.4.8. Self-Billing Indicator</a></h4>
 <div class="paragraph">
 <p>Self-billing invoices can be indicated in two ways:</p>
 </div>
@@ -12756,7 +12821,7 @@ Reference examples are available under <code>examples/country-specific-examples/
 </div>
 </div>
 <div class="sect3">
-<h4 id="_business_and_vat_identification"><a class="anchor" href="#_business_and_vat_identification"></a><a class="link" href="#_business_and_vat_identification">5.4.8. Business and VAT Identification</a></h4>
+<h4 id="_business_and_vat_identification"><a class="anchor" href="#_business_and_vat_identification"></a><a class="link" href="#_business_and_vat_identification">5.4.9. Business and VAT Identification</a></h4>
 <div class="paragraph">
 <p>France uses SIRET (14-digit) and SIREN (9-digit) numbers for business identification.</p>
 </div>
@@ -12930,7 +12995,7 @@ SUFFIX and CODE ROUTAGE achieve similar functionality at different organizationa
 </div>
 </div>
 <div class="sect3">
-<h4 id="_mandate_scenarios_agent_parties"><a class="anchor" href="#_mandate_scenarios_agent_parties"></a><a class="link" href="#_mandate_scenarios_agent_parties">5.4.9. Mandate Scenarios - Agent Parties</a></h4>
+<h4 id="_mandate_scenarios_agent_parties"><a class="anchor" href="#_mandate_scenarios_agent_parties"></a><a class="link" href="#_mandate_scenarios_agent_parties">5.4.10. Mandate Scenarios - Agent Parties</a></h4>
 <div class="paragraph">
 <p>France supports multiple mandate scenarios requiring agent party information. Party roles are indicated using the PUF RoleCode extension.</p>
 </div>
@@ -13112,7 +13177,7 @@ The role code for Invoicer MUST be exactly <code>II</code> as per French busines
 </div>
 </div>
 <div class="sect3">
-<h4 id="_service_code"><a class="anchor" href="#_service_code"></a><a class="link" href="#_service_code">5.4.10. Service code</a></h4>
+<h4 id="_service_code"><a class="anchor" href="#_service_code"></a><a class="link" href="#_service_code">5.4.11. Service code</a></h4>
 <div class="paragraph">
 <p>Service code is a routing code required by some customers to identify the correct recipient in French Government Portal.</p>
 </div>
@@ -13163,7 +13228,7 @@ The role code for Invoicer MUST be exactly <code>II</code> as per French busines
 </div>
 </div>
 <div class="sect3">
-<h4 id="_b2g_public_sector_chorus_pro"><a class="anchor" href="#_b2g_public_sector_chorus_pro"></a><a class="link" href="#_b2g_public_sector_chorus_pro">5.4.11. B2G / public sector (Chorus Pro)</a></h4>
+<h4 id="_b2g_public_sector_chorus_pro"><a class="anchor" href="#_b2g_public_sector_chorus_pro"></a><a class="link" href="#_b2g_public_sector_chorus_pro">5.4.12. B2G / public sector (Chorus Pro)</a></h4>
 <div class="paragraph">
 <p>French B2G invoices are subject to the additional <code>BR-FR-CPRO</code> rules. The rules are activated when the transaction is identified as B2G through <code>#ADN#B2G</code>, channel context, or public-buyer directory information.</p>
 </div>
@@ -13225,7 +13290,7 @@ The role code for Invoicer MUST be exactly <code>II</code> as per French busines
 </div>
 </div>
 <div class="sect3">
-<h4 id="_legal_commitments"><a class="anchor" href="#_legal_commitments"></a><a class="link" href="#_legal_commitments">5.4.12. Legal commitments</a></h4>
+<h4 id="_legal_commitments"><a class="anchor" href="#_legal_commitments"></a><a class="link" href="#_legal_commitments">5.4.13. Legal commitments</a></h4>
 <div class="paragraph">
 <p>Entities behind French Government portal can set up validation of certain elements called legal commitments. Therefore it&#8217;s recommended to support the below values in order to fulfill the requirements of this validation.</p>
 </div>

--- a/specification/country-specifics/france.adoc
+++ b/specification/country-specifics/france.adoc
@@ -109,7 +109,7 @@ Each text code must be provided in a separate `cbc:Note` element with the format
 |#BAR#
 |Treatment type qualification
 |Type of treatment expected for the invoice
-|*One of:* `B2B`, `B2BINT`, `B2C`, `OUTOFSCOPE`, `ARCHIVEONLY`
+|*One of:* `B2B`, `B2BINT`, `B2C`, `B2CINT`, `OUTOFSCOPE`, `ARCHIVEONLY`
 
 |#BLU#
 |Eco-participation/Eco-contribution
@@ -155,7 +155,7 @@ Each text code must be provided in a separate `cbc:Note` element with the format
 IMPORTANT:
 
 * The #PMT# fixed indemnity amount is legally set at €40.00 per Article L441-10 of the French Commercial Code
-* #BAR# is mandatory for every non-B2G France scenario and must contain exactly ONE of the specified values: `B2B` (e-invoicing), `B2BINT` (B2B international e-reporting), `B2C` (B2C e-reporting), `OUTOFSCOPE` (outside reform scope), or `ARCHIVEONLY` (internal credit note - no transmission)
+* #BAR# is mandatory for every non-B2G France scenario and must contain exactly ONE of the specified values: `B2B` (e-invoicing), `B2BINT` (B2B international e-reporting), `B2C` (B2C e-reporting), `B2CINT` (B2C international e-reporting), `OUTOFSCOPE` (outside reform scope), or `ARCHIVEONLY` (internal credit note, see <<_archive_only_credit_notes_archiveonly, Archive-only credit notes>>).
 * #BAR# is not required for B2G. B2G examples use `#ADN#B2G` and should provide `puf:ComplianceActivatedIndicator` = `true`
 * Only ONE #BAR# note is allowed per invoice
 * `#REG#` can be used for seller registration data such as share capital and other regulatory company information
@@ -215,7 +215,7 @@ Explicit indicator (authoritative)::
 Set `puf:ComplianceExtension/puf:ComplianceActivatedIndicator` (see <<_compliance_extension>>) to `true` for *REGULATED* or `false` for *NON_REGULATED*. When present, this value takes precedence.
 
 `#BAR#` treatment-type note (non-B2G fallback)::
-For non-B2G documents, when the explicit indicator is absent, Pagero Online derives the status from the mandatory `#BAR#` note (see <<_french_text_codes_note_elements, French Text Codes>>): `#BAR#B2B` is treated as *REGULATED*; every other treatment type (`B2BINT`, `B2C`, `OUTOFSCOPE`, `ARCHIVEONLY`) is treated as *NON_REGULATED*.
+For non-B2G documents, when the explicit indicator is absent, Pagero Online derives the status from the mandatory `#BAR#` note (see <<_french_text_codes_note_elements, French Text Codes>>): `#BAR#B2B` is treated as *REGULATED*; every other treatment type (`B2BINT`, `B2C`, `B2CINT`, `OUTOFSCOPE`, `ARCHIVEONLY`) is treated as *NON_REGULATED*.
 
 B2G classification::
 For B2G, `#BAR#` is not required. `#ADN#B2G` is the invoice-level B2G indicator used by the Chorus Pro qualification examples. Pagero senders should also set `puf:ComplianceActivatedIndicator` to `true`; channel or directory context may independently identify the transaction as B2G.
@@ -245,6 +245,35 @@ Declaring the regulated / non-regulated status is the *sender's responsibility*.
     <!-- Equivalent fallback when the explicit indicator is omitted: <cbc:Note>#BAR#B2B</cbc:Note> -->
     <!-- Code omitted for clarity -->
 </Invoice>
+----
+
+==== Archive-only credit notes (ARCHIVEONLY)
+
+`#BAR#ARCHIVEONLY` marks an *internal credit note* (AVOIR interne) reversing an invoice that was
+*Rejetée* or *Refusée*, submitted for archiving only. Per AFNOR XP Z12-012 rule BR-FR-20 such a
+document must not be subject to e-invoicing processing: no flux 1 and no transmission to the recipient.
+Pagero Online will neither clear it nor deliver it, so it never reaches the buyer.
+
+Send it as a credit note and reference the reversed invoice in BG-3, which is what XP Z12-014 §2.2
+scopes the behaviour to. Do not add `puf:ExternalDeliveryType`; it is not needed for this case.
+
+*Example — archive-only credit note*
+[source,xml]
+----
+<CreditNote>
+    <!-- Code omitted for clarity -->
+    <cbc:CreditNoteTypeCode name="B1">381</cbc:CreditNoteTypeCode>
+    <cbc:Note>#BAR#ARCHIVEONLY</cbc:Note>
+
+    <!-- BG-3 reference to the reversed invoice -->
+    <cac:BillingReference>
+        <cac:InvoiceDocumentReference>
+            <cbc:ID>INV-2026-000123</cbc:ID>
+            <cbc:IssueDate>2026-09-01</cbc:IssueDate>
+        </cac:InvoiceDocumentReference>
+    </cac:BillingReference>
+    <!-- Code omitted for clarity -->
+</CreditNote>
 ----
 
 ==== Credit note for global discount (Code 262)

--- a/specification/extensions/document-level/ComplianceExtension.adoc
+++ b/specification/extensions/document-level/ComplianceExtension.adoc
@@ -27,6 +27,11 @@ When set to `true`, the document must not be sent to a clearance authority, even
 `puf:ComplianceActivatedIndicator` is a generic indicator, intended to be reused across markets and expected to be expanded for additional markets over time. It is *currently only applied in France*, where it signals whether the document is processed *within* or *outside* the French e-invoicing reform: when `true`, Pagero — acting as the accredited platform (PA) — applies the stricter compliance checks and validations the reform requires; when `false`, the document is processed outside that stricter regime. See the France country-specifics for how these extensions are used.
 ====
 
+[NOTE]
+====
+For France, `puf:ComplianceActivatedIndicator` takes precedence over the mandatory `#BAR#` treatment-type note. A `#BAR#ARCHIVEONLY` note additionally suppresses clearance and delivery; see <<_france, France>> for what Pagero Online does with that document.
+====
+
 See example below as well as the URI to be used for this extension.
 
 *Example*

--- a/specification/extensions/document-level/ExternalDeliveryType.adoc
+++ b/specification/extensions/document-level/ExternalDeliveryType.adoc
@@ -17,6 +17,13 @@ Indicates that the document should be processed without standard Pagero routing 
 
 |===
 
+[NOTE]
+====
+The two values differ in whether the recipient can see the document. With `PROCESS_WITHOUT_DELIVERY` the
+document is still routed, so a recipient who is also a Pagero customer will see it even though no file is
+delivered. `PROCESS_WITHOUT_ROUTING` keeps it with the issuing customer alone.
+====
+
 See example below as well as the URI to be used for this extension.
 
 *Example*


### PR DESCRIPTION
Documents the `ARCHIVEONLY` treatment type for France, which was listed as a valid `#BAR#` value but never explained. It covers an internal credit note reversing a Rejetee or Refusee invoice: send it as a credit note, reference the reversed invoice in BG-3, and Pagero Online will neither clear nor deliver it. Adds a worked example.

Also adds `B2CINT` to the BAR value list, which FNFE added to BR-FR-20 in V1.4.0, and records on the ExternalDeliveryType page that `PROCESS_WITHOUT_DELIVERY` still routes the document, so a recipient who is also a Pagero customer can see it. That distinction is what caused the customer report behind this work.

Tests: XSD sweep 219/219; PUF Schematron clean on the new example; internal transform and FNFE Flux 2 UBL V1.4.0 clean on the resulting France UBL target; publication builds with `--failure-level=WARN` and both cross-references resolve.

Work item: [5706841](https://dev.azure.com/tr-tax/TaxTrade/_workitems/edit/5706841)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
