### PR TITLE
France - PUF Billing - documentation - assujetti unique (ICD 0231)

### DIFF
--- a/examples/country-specific-examples/france/PUF_France_UC29_SingleVATEntity_CreditNote.xml
+++ b/examples/country-specific-examples/france/PUF_France_UC29_SingleVATEntity_CreditNote.xml
@@ -1,0 +1,287 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    PUF France Use Case 29: Single VAT Entity (Assujetti Unique) - Credit Note
+
+    Business Scenario:
+    - Filiale Alpha SAS is a member of the single taxable entity "Groupe Fiscal Innovatech"
+    - It previously invoiced the external third party Acheteur Beta SARL with ALPHA-2026-0198
+      (8 rack servers, 2,400.00 HT + 480.00 VAT = 2,880.00 TTC)
+    - Two servers are returned, so the member issues a credit note to the same third party
+
+    Key UC29 Credit Note Concepts:
+    - The three cumulative single-taxable-entity requirements apply to the credit note exactly
+      as they apply to the invoice, because the fatal rules BR-FR-CO-14 and BR-FR-CO-15 have
+      context "ubl:Invoice | cn:CreditNote"
+    - BT-29 with scheme identifier 0231 carries the SIREN of the single taxable entity, which is
+      a different legal entity from the seller. The seller's own SIREN stays in BT-30 with scheme 0002
+    - BG-11 (TaxRepresentativeParty) carries the entity company name, intra-community VAT number
+      and postal address, because EN 16931 has no dedicated single-taxable-entity block
+    - A note with subject code TXD (BT-21) and text MEMBRE_ASSUJETTI_UNIQUE (BT-22) is mandatory
+    - 0231 is a seller private identifier only. It must never appear on the buyer, on BT-30,
+      or on an electronic address (BT-34/BT-49), which stay on scheme 0225
+
+    Worked Example:
+    - Original invoice: 8 x 300.00 = 2,400.00 HT + 480.00 VAT = 2,880.00 TTC
+    - Returned quantity: 2 servers
+    - Credit note HT: 600.00 EUR
+    - Credit note VAT @ 20%: 120.00 EUR
+    - Credit note TTC: 720.00 EUR
+
+    Source: XP Z12-014 Annexe A V1.4, Section 3.2.28 (Case No. 29)
+            BR-FR-Flux2-Schematron-UBL V1.4.0, patterns BR-FR-CO-14, BR-FR-CO-15, BR-FR-32
+-->
+<CreditNote xmlns="urn:pagero:PageroUniversalFormat:CreditNote:1.0" xmlns:cac="urn:pagero:CommonAggregateComponents:1.0" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:puf="urn:pagero:ExtensionComponent:1.0" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+
+    <!-- BT-24 Specification identifier -->
+    <ext:UBLExtensions>
+        <ext:UBLExtension>
+            <ext:ExtensionURI>urn:pagero:ExtensionComponent:1.0:PageroExtension:ComplianceExtension</ext:ExtensionURI>
+            <ext:ExtensionContent>
+                <puf:PageroExtension>
+                    <puf:ComplianceExtension>
+                        <!-- REGULATED (true) / NON_REGULATED (false); authoritative, equivalent to #BAR# -->
+                        <puf:ComplianceActivatedIndicator>true</puf:ComplianceActivatedIndicator>
+                    </puf:ComplianceExtension>
+                </puf:PageroExtension>
+            </ext:ExtensionContent>
+        </ext:UBLExtension>
+    </ext:UBLExtensions>
+    <cbc:CustomizationID>urn:pagero.com:puf:billing:2.0</cbc:CustomizationID>
+    <!-- BT-23 Business process type -->
+    <cbc:ProfileID>urn:pagero.com:puf:billing:1.0</cbc:ProfileID>
+    <!-- BT-1 Credit Note Number -->
+    <cbc:ID>ALPHA-2026-AV-0043</cbc:ID>
+    <!-- BT-2 Credit Note Issue Date -->
+    <cbc:IssueDate>2026-03-05</cbc:IssueDate>
+    <!-- BT-3 Credit Note Type Code - 381: Credit note -->
+    <!-- @name = B1: Goods credit note -->
+    <cbc:CreditNoteTypeCode name="B1">381</cbc:CreditNoteTypeCode>
+
+    <!-- BT-22 / BT-21: French text codes -->
+    <!-- #REG# Registration information -->
+    <cbc:Note>#REG#SAS au capital de 500 000 EUR — RCS Paris B 333 444 555 — SIRET 33344455566677 — Membre de l'assujetti unique Groupe Fiscal Innovatech (SIREN 888 999 000)</cbc:Note>
+    <!-- #ABL# Trade register -->
+    <cbc:Note>#ABL#RCS Paris B 333 444 555</cbc:Note>
+    <!-- #AAI# APE code -->
+    <cbc:Note>#AAI#APE 4651Z — Commerce de gros d'ordinateurs, d'équipements informatiques périphériques et de logiciels</cbc:Note>
+    <!-- #PMD# Late payment penalties -->
+    <cbc:Note>#PMD#En cas de retard de paiement, pénalités au taux BCE + 10 points et indemnité forfaitaire de recouvrement de 40 EUR</cbc:Note>
+    <!-- #PMT# Fixed indemnity -->
+    <cbc:Note>#PMT#Indemnité forfaitaire pour frais de recouvrement : 40 EUR</cbc:Note>
+    <!-- Explanation of credit note reason; unprefixed notes precede the #BAR# note in UBL per BR-FR-20 -->
+    <cbc:Note>Avoir pour retour de 2 serveurs rack sur la facture ALPHA-2026-0198</cbc:Note>
+    <!-- #BAR# Treatment type -->
+    <cbc:Note>#BAR#B2B</cbc:Note>
+    <cbc:Note>#AAB#Pas d'escompte pour paiement anticipé</cbc:Note>
+    <!--
+        MANDATORY NOTE per BR-FR-CO-14:
+        BT-21 = TXD, BT-22 = "MEMBRE_ASSUJETTI_UNIQUE"
+        The rule concatenates all notes and reads the text after #TXD# up to the next '#',
+        so this note is placed last.
+    -->
+    <cbc:Note>#TXD#MEMBRE_ASSUJETTI_UNIQUE</cbc:Note>
+
+    <!-- BT-5 Credit Note Document Currency -->
+    <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+
+    <!-- BT-10 Buyer reference -->
+    <cbc:BuyerReference>BETA-PO-2026-0445</cbc:BuyerReference>
+
+    <!-- BT-25 Preceding Invoice Reference (mandatory for credit notes) -->
+    <cac:BillingReference>
+        <cac:InvoiceDocumentReference>
+            <cbc:ID>ALPHA-2026-0198</cbc:ID>
+            <cbc:IssueDate>2026-02-20</cbc:IssueDate>
+        </cac:InvoiceDocumentReference>
+    </cac:BillingReference>
+
+    <!-- BG-4 Seller — Group MEMBER company (Filiale Alpha SAS) -->
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <!-- BT-34 Seller electronic address (member's own SIRET); 0231 is not an EAS value per BR-CL-25 -->
+            <cbc:EndpointID schemeID="0225">33344455566677</cbc:EndpointID>
+
+            <!--
+                BT-29 identifiers — TWO entries required for a single taxable entity member:
+                1. Member's own SIRET (schemeID 0009)
+                2. Single VAT Entity SIREN (schemeID 0231) — MANDATORY
+                BR-FR-CO-10 allows at most one identifier per schemeID, so 0231 appears exactly once.
+            -->
+            <!-- Entry 1: Member's own SIRET -->
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="0009">33344455566677</cbc:ID>
+            </cac:PartyIdentification>
+            <!--
+                Entry 2: Single VAT Entity SIREN (schemeID 0231)
+                Exactly 9 digits per BR-FR-32, and different from the member's own SIREN in BT-30.
+            -->
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="0231">888999000</cbc:ID>
+            </cac:PartyIdentification>
+
+            <!-- BT-28 Seller trading name (member company trading name) -->
+            <cac:PartyName>
+                <cbc:Name>Filiale Alpha Informatique</cbc:Name>
+            </cac:PartyName>
+
+            <!-- BG-5 Seller postal address (member's own address) -->
+            <cac:PostalAddress>
+                <cbc:StreetName>14 Avenue de la Grande Armée</cbc:StreetName>
+                <cbc:CityName>Paris</cbc:CityName>
+                <cbc:PostalZone>75017</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>FR</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+
+            <!--
+                BT-31: Member's own VAT identifier.
+                The VAT liable for this credit note is the entity's (BT-63 in BG-11).
+            -->
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>FR33333444555</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+
+            <!-- BT-27 Seller legal name / BT-30 Member's own SIREN -->
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Filiale Alpha SAS</cbc:RegistrationName>
+                <cbc:CompanyID schemeID="0002">333444555</cbc:CompanyID>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+
+    <!-- BG-7 Buyer — External third party (no 0231 identifier per BR-FR-CO-11) -->
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <!-- BT-49 Buyer electronic address (buyer's SIRET) -->
+            <cbc:EndpointID schemeID="0225">11122233344456</cbc:EndpointID>
+            <!-- BT-46 Buyer SIRET -->
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="0009">11122233344456</cbc:ID>
+            </cac:PartyIdentification>
+            <!-- BT-45 Buyer trading name -->
+            <cac:PartyName>
+                <cbc:Name>Acheteur Beta</cbc:Name>
+            </cac:PartyName>
+            <!-- BG-8 Buyer postal address -->
+            <cac:PostalAddress>
+                <cbc:StreetName>22 Rue de la Bourse</cbc:StreetName>
+                <cbc:CityName>Lyon</cbc:CityName>
+                <cbc:PostalZone>69002</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>FR</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <!-- BT-48 Buyer VAT identifier -->
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>FR11111222333</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <!-- BT-44 Buyer legal name / BT-47 SIREN -->
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Acheteur Beta SARL</cbc:RegistrationName>
+                <cbc:CompanyID schemeID="0002">111222333</cbc:CompanyID>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+
+    <!--
+        BG-11 Seller Tax Representative Party — Single VAT Entity data.
+        MANDATORY per BR-FR-CO-15 whenever the seller carries a 0231 identifier.
+
+        BT-62: Entity business name
+        BT-63: Entity intra-community VAT number
+        BG-12: Entity postal address
+    -->
+    <cac:TaxRepresentativeParty>
+        <!-- BT-62 Single VAT Entity business name -->
+        <cac:PartyName>
+            <cbc:Name>Groupe Fiscal Innovatech</cbc:Name>
+        </cac:PartyName>
+        <!-- BG-12 Single VAT Entity postal address -->
+        <cac:PostalAddress>
+            <cbc:StreetName>Tour Innovatech, 1 Parvis de la Défense</cbc:StreetName>
+            <cbc:CityName>Puteaux</cbc:CityName>
+            <cbc:PostalZone>92800</cbc:PostalZone>
+            <cac:Country>
+                <cbc:IdentificationCode>FR</cbc:IdentificationCode>
+            </cac:Country>
+        </cac:PostalAddress>
+        <!-- BT-63 Single VAT Entity intra-community VAT number -->
+        <cac:PartyTaxScheme>
+            <cbc:CompanyID>FR88888999000</cbc:CompanyID>
+            <cac:TaxScheme>
+                <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+        </cac:PartyTaxScheme>
+    </cac:TaxRepresentativeParty>
+
+    <!-- BG-19 Payment instructions -->
+    <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+            <cbc:ID>FR7630006000011122233440001</cbc:ID>
+            <cbc:Name>Filiale Alpha SAS</cbc:Name>
+            <cac:FinancialInstitutionBranch>
+                <cbc:ID>BNPAFRPPXXX</cbc:ID>
+            </cac:FinancialInstitutionBranch>
+        </cac:PayeeFinancialAccount>
+    </cac:PaymentMeans>
+
+    <!-- BG-20 Payment terms -->
+    <cac:PaymentTerms>
+        <cbc:Note>Avoir à déduire de la prochaine facture</cbc:Note>
+    </cac:PaymentTerms>
+
+    <!-- BG-23 VAT Breakdown -->
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">120.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="EUR">600.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="EUR">120.00</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>20.00</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+
+    <!-- BG-22 Document totals -->
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">600.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">600.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">720.00</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">720.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+
+    <!-- BG-25 Credit Note Line 1 — 2 of the 8 invoiced servers returned -->
+    <cac:CreditNoteLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:CreditedQuantity unitCode="H87">2</cbc:CreditedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">600.00</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Description>Retour de 2 serveurs rack 2U (facture ALPHA-2026-0198, ligne 1)</cbc:Description>
+            <cbc:Name>Serveur rack professionnel 2U</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>20.00</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="EUR">300.00</cbc:PriceAmount>
+            <cbc:BaseQuantity unitCode="H87">1</cbc:BaseQuantity>
+        </cac:Price>
+    </cac:CreditNoteLine>
+
+</CreditNote>

--- a/examples/country-specific-examples/france/README.md
+++ b/examples/country-specific-examples/france/README.md
@@ -741,6 +741,26 @@ Demonstrates:
 
 ---
 
+#### UC29 (alt): PUF_France_UC29_SingleVATEntity_CreditNote.xml
+
+**Single VAT Entity Member Credit Note (Assujetti Unique)**
+
+Demonstrates:
+
+- The credit note counterpart of `PUF_France_UC29_SingleVATEntity_Invoice.xml`, crediting a partial return
+- The same three cumulative requirements on a credit note, since `BR-FR-CO-14` and `BR-FR-CO-15` have context `ubl:Invoice | cn:CreditNote`
+- BG-3 reference to the original invoice (ALPHA-2026-0198)
+- The unprefixed credit reason note placed before the `#BAR#` note, and `#TXD#MEMBRE_ASSUJETTI_UNIQUE` placed last
+
+**Key Features:**
+
+- Document type 381 (Credit note) with business process B1
+- 2 of the 8 invoiced servers returned: 600.00 HT + 120.00 VAT = 720.00 TTC
+- Entity SIREN in BT-29 schemeID 0231 (nine digits per `BR-FR-32`) differs from the member's own SIREN in BT-30 schemeID 0002
+- 0231 appears only once, only on the seller, and never on BT-34/BT-49, which stay on schemeID 0225
+
+---
+
 #### UC30: PUF_France_UC30_VATAlreadyCollected.xml
 
 **VAT Already Collected**
@@ -1019,7 +1039,13 @@ Invoice e-reporting examples (UC43, UC44) are located in the **tax-data-report**
 | **#CUS#** | Customs information | Customs-related details and information | *(free text)* |
 | **#PAI#** | Third party payment | Third party payment information (e.g. partial third-party payer or barter arrangement) | *(free text)* |
 | **#SUR#** | Supplier notes | Additional remarks from the supplier | *(free text)* |
-| **#TXD#** | Single taxable person member | Identifies a member of a single taxable person (assujetti unique) — for external transactions only | `Membre d'un assujetti unique` |
+| **#TXD#** | Single taxable person member | Identifies a member of a single taxable person (assujetti unique), for external transactions only. Mandatory whenever the seller party carries identification scheme `0231`. | `MEMBRE_ASSUJETTI_UNIQUE` |
+
+The `#CODE#` prefix is a text convention inside the note text. `cbc:Note` extends a bare text type with no note-code component, so neither the PUF schema nor PUF validation can check the prefix; it is split into the subject code (BT-21) and the note text (BT-22) when the document is transformed to the French target format.
+
+`#TXD#` must carry the literal value `MEMBRE_ASSUJETTI_UNIQUE`. The French phrase `Membre d'un assujetti unique` is the value BR-FR-MAP-06 and BR-FR-MAP-07 require in the downstream Flux 1 note text (BT-22) and Flux 10.1 report note (TT-27), and is never what a source document carries.
+
+The `#TXD#` note must be the last `cbc:Note` of the document, or the note that follows it must itself begin with a text code prefix. `BR-FR-CO-14` joins all document-level notes into one string with no separator and reads the value between the TXD prefix and the next hash character, so a following note without a text code prefix is absorbed into that value and the fatal rule fires.
 
 ## Business Process Types
 

--- a/index.html
+++ b/index.html
@@ -4504,7 +4504,8 @@ Identifier of the party.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:PartyIdentification/cbc:ID/@schemeID</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Party Identifier Scheme</strong><br>
 Scheme identifier of party identifier.<br>
-Value must be according to code list <a href="https://pagero.github.io/puf-code-lists/#_puf_008_identificationscheme" target="_blank" rel="noopener">PUF-008-IDENTIFICATIONSCHEME</a>.</p></td>
+Value must be according to code list <a href="https://pagero.github.io/puf-code-lists/#_puf_008_identificationscheme" target="_blank" rel="noopener">PUF-008-IDENTIFICATIONSCHEME</a>.<br>
+For France, scheme <code>0231</code> on <code>cac:AccountingSupplierParty/cac:Party/cac:PartyIdentification/cbc:ID</code> is the SIREN of the single taxable person (assujetti unique) that the seller is a member of. It is allowed on the seller only, exactly once, and must be exactly 9 digits. It is an ISO 6523 ICD value and not a CEF EAS value, so it must never be used as an electronic address in <code>cbc:EndpointID</code>. <code>cac:PartyLegalEntity/cbc:CompanyID</code> with scheme <code>0002</code> remains the seller&#8217;s own SIREN. Using <code>0231</code> also obliges the sender to provide the note <code>#TXD#MEMBRE_ASSUJETTI_UNIQUE</code> and a <code>cac:TaxRepresentativeParty</code> carrying the name, VAT number and postal address of the single taxable person.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>cac:PartyName/cbc:Name</code></p></td>
@@ -12301,6 +12302,18 @@ See <a href="https://pagero.github.io/puf-code-lists/#_tax_category_codes_croati
 <div class="paragraph">
 <p>Each text code must be provided in a separate <code>cbc:Note</code> element with the format: <code>#CODE#value</code></p>
 </div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+<code>cbc:Note</code> is typed as <code>NoteType</code>, which extends a bare text type and has no note-code component. The subject code is therefore not carried as a code of its own, and the <code><mark>CODE</mark></code> prefix is a text convention inside the note text that neither the PUF schema nor PUF validation can check. The prefix is split into the subject code (BT-21) and the note text (BT-22) when the document is transformed to the French target format.
+</td>
+</tr>
+</table>
+</div>
 </div>
 <div class="sect4">
 <h5 id="_available_text_codes"><a class="anchor" href="#_available_text_codes"></a><a class="link" href="#_available_text_codes">Available Text Codes</a></h5>
@@ -12407,8 +12420,8 @@ See <a href="https://pagero.github.io/puf-code-lists/#_tax_category_codes_croati
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><mark>TXD</mark></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Single taxable person member</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Mention of the member of a single taxable person</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Required:</strong> <code>Membre d&#8217;un assujetti unique</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Mention that the seller is a member of a single taxable person (assujetti unique). Mandatory whenever the seller party carries identification scheme <code>0231</code>, see <a href="#_single_taxable_person_identification_assujetti_unique">Single Taxable Person Identification</a>.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Required:</strong> <code>MEMBRE_ASSUJETTI_UNIQUE</code></p></td>
 </tr>
 </tbody>
 </table>
@@ -12431,6 +12444,12 @@ See <a href="https://pagero.github.io/puf-code-lists/#_tax_category_codes_croati
 </li>
 <li>
 <p><code><mark>REG</mark></code> can be used for seller registration data such as share capital and other regulatory company information</p>
+</li>
+<li>
+<p><code><mark>TXD</mark></code> must carry the literal value <code>MEMBRE_ASSUJETTI_UNIQUE</code>. The French phrase <code>Membre d&#8217;un assujetti unique</code> is the value BR-FR-MAP-06 and BR-FR-MAP-07 require in the downstream Flux 1 note text (BT-22) and Flux 10.1 report note (TT-27), and is never what a source document carries</p>
+</li>
+<li>
+<p>The <code><mark>TXD</mark></code> note must be the last <code>cbc:Note</code> of the document, or the note that follows it must itself begin with a text code prefix. <code>BR-FR-CO-14</code> joins all document-level notes into one string with no separator and reads the value between the TXD prefix and the next hash character, so a following note without a text code prefix is absorbed into that value and the fatal rule fires</p>
 </li>
 </ul>
 </div>
@@ -12465,7 +12484,7 @@ See <a href="https://pagero.github.io/puf-code-lists/#_tax_category_codes_croati
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
     <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
-    <span class="tag">&lt;cbc:Note&gt;</span>#TXD#Membre d'un assujetti unique<span class="tag">&lt;/cbc:Note&gt;</span>
+    <span class="tag">&lt;cbc:Note&gt;</span>#TXD#MEMBRE_ASSUJETTI_UNIQUE<span class="tag">&lt;/cbc:Note&gt;</span>
     <span class="tag">&lt;cbc:Note&gt;</span>#BAR#B2B<span class="tag">&lt;/cbc:Note&gt;</span>
     <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
 <span class="tag">&lt;/Invoice&gt;</span></code></pre>
@@ -13019,6 +13038,136 @@ SUFFIX and CODE ROUTAGE achieve similar functionality at different organizationa
     <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
 <span class="tag">&lt;/Invoice&gt;</span></code></pre>
 </div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_single_taxable_person_identification_assujetti_unique"><a class="anchor" href="#_single_taxable_person_identification_assujetti_unique"></a><a class="link" href="#_single_taxable_person_identification_assujetti_unique">Single Taxable Person Identification (Assujetti Unique)</a></h5>
+<div class="paragraph">
+<p>Identification scheme <code>0231</code> carries the SIREN of the single taxable person (assujetti unique) that the seller is a member of. It identifies a legal entity other than the seller, and it is valid only as a seller private identifier (BT-29):</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Provide it on <code>cac:AccountingSupplierParty/cac:Party/cac:PartyIdentification/cbc:ID</code> with <code>@schemeID</code> <code>0231</code>. Scheme <code>0231</code> must never be used on the buyer, on any other party, or on <code>cac:PartyLegalEntity/cbc:CompanyID</code>.</p>
+</li>
+<li>
+<p>Provide it exactly once. Only one identifier per scheme is allowed for a party (<code>BR-FR-CO-10</code>).</p>
+</li>
+<li>
+<p>The value must be exactly 9 digits (<code>BR-FR-32</code>).</p>
+</li>
+<li>
+<p><code>0231</code> is an ISO 6523 ICD value and not a CEF EAS value, so it must never be used as an electronic address in <code>cbc:EndpointID</code> (BT-34 and BT-49), which would breach <code>BR-CL-25</code>.</p>
+</li>
+<li>
+<p>The value must be the SIREN of a single taxable person registered in the PPF Annuaire (<code>BR-FR-CO-13</code>). This is a business rule verified by the PPF, with no Schematron implementation, and senders cannot pre-check it: the Annuaire data model has no representation of a single taxable person.</p>
+</li>
+<li>
+<p><code>cac:PartyLegalEntity/cbc:CompanyID</code> with scheme <code>0002</code> is unaffected and remains the seller&#8217;s own SIREN (BT-30).</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Using scheme <code>0231</code> obliges the sender to provide two further elements in the same document:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>The note <code>#TXD#MEMBRE_ASSUJETTI_UNIQUE</code> (<code>BR-FR-CO-14</code>), see <a href="#_french_text_codes_note_elements">French Text Codes</a>. Place it as the last <code>cbc:Note</code> of the document, or immediately before another note that begins with a text code prefix. <code>BR-FR-CO-14</code> joins all document-level notes into one string with no separator and reads the value between the TXD prefix and the next hash character, so a following note without a text code prefix is absorbed into that value and the fatal rule fires.</p>
+</li>
+<li>
+<p>A <code>cac:TaxRepresentativeParty</code> (BG-11) carrying the name, VAT number (BT-63) and postal address of the single taxable person (<code>BR-FR-CO-15</code>). The VAT for the invoice is declared by the single taxable person, not by the seller.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>Example</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="xml"><span class="tag">&lt;Invoice&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+    <span class="tag">&lt;cbc:Note&gt;</span>#TXD#MEMBRE_ASSUJETTI_UNIQUE<span class="tag">&lt;/cbc:Note&gt;</span><i class="conum" data-value="1"></i><b>(1)</b>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+    <span class="tag">&lt;cac:AccountingSupplierParty&gt;</span>
+        <span class="tag">&lt;cac:Party&gt;</span>
+            <span class="tag">&lt;cbc:EndpointID</span> <span class="attribute-name">schemeID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">0225</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>33344455566677<span class="tag">&lt;/cbc:EndpointID&gt;</span><i class="conum" data-value="2"></i><b>(2)</b>
+            <span class="tag">&lt;cac:PartyIdentification&gt;</span>
+                <span class="tag">&lt;cbc:ID</span> <span class="attribute-name">schemeID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">0009</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>33344455566677<span class="tag">&lt;/cbc:ID&gt;</span><i class="conum" data-value="3"></i><b>(3)</b>
+            <span class="tag">&lt;/cac:PartyIdentification&gt;</span>
+            <span class="tag">&lt;cac:PartyIdentification&gt;</span>
+                <span class="tag">&lt;cbc:ID</span> <span class="attribute-name">schemeID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">0231</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>888999000<span class="tag">&lt;/cbc:ID&gt;</span><i class="conum" data-value="4"></i><b>(4)</b>
+            <span class="tag">&lt;/cac:PartyIdentification&gt;</span>
+            <span class="tag">&lt;cac:PartyLegalEntity&gt;</span>
+                <span class="tag">&lt;cbc:RegistrationName&gt;</span>Filiale Alpha SAS<span class="tag">&lt;/cbc:RegistrationName&gt;</span>
+                <span class="tag">&lt;cbc:CompanyID</span> <span class="attribute-name">schemeID</span>=<span class="string"><span class="delimiter">&quot;</span><span class="content">0002</span><span class="delimiter">&quot;</span></span><span class="tag">&gt;</span>333444555<span class="tag">&lt;/cbc:CompanyID&gt;</span><i class="conum" data-value="5"></i><b>(5)</b>
+            <span class="tag">&lt;/cac:PartyLegalEntity&gt;</span>
+            <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+        <span class="tag">&lt;/cac:Party&gt;</span>
+    <span class="tag">&lt;/cac:AccountingSupplierParty&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+    <span class="tag">&lt;cac:TaxRepresentativeParty&gt;</span><i class="conum" data-value="6"></i><b>(6)</b>
+        <span class="tag">&lt;cac:PartyName&gt;</span>
+            <span class="tag">&lt;cbc:Name&gt;</span>Groupe Fiscal Innovatech<span class="tag">&lt;/cbc:Name&gt;</span>
+        <span class="tag">&lt;/cac:PartyName&gt;</span>
+        <span class="tag">&lt;cac:PostalAddress&gt;</span>
+            <span class="tag">&lt;cbc:StreetName&gt;</span>Tour Innovatech, 1 Parvis de la Défense<span class="tag">&lt;/cbc:StreetName&gt;</span>
+            <span class="tag">&lt;cbc:CityName&gt;</span>Puteaux<span class="tag">&lt;/cbc:CityName&gt;</span>
+            <span class="tag">&lt;cbc:PostalZone&gt;</span>92800<span class="tag">&lt;/cbc:PostalZone&gt;</span>
+            <span class="tag">&lt;cac:Country&gt;</span>
+                <span class="tag">&lt;cbc:IdentificationCode&gt;</span>FR<span class="tag">&lt;/cbc:IdentificationCode&gt;</span>
+            <span class="tag">&lt;/cac:Country&gt;</span>
+        <span class="tag">&lt;/cac:PostalAddress&gt;</span>
+        <span class="tag">&lt;cac:PartyTaxScheme&gt;</span>
+            <span class="tag">&lt;cbc:CompanyID&gt;</span>FR88888999000<span class="tag">&lt;/cbc:CompanyID&gt;</span>
+            <span class="tag">&lt;cac:TaxScheme&gt;</span>
+                <span class="tag">&lt;cbc:ID&gt;</span>VAT<span class="tag">&lt;/cbc:ID&gt;</span>
+            <span class="tag">&lt;/cac:TaxScheme&gt;</span>
+        <span class="tag">&lt;/cac:PartyTaxScheme&gt;</span>
+    <span class="tag">&lt;/cac:TaxRepresentativeParty&gt;</span>
+    <span class="comment">&lt;!-- Code omitted for clarity --&gt;</span>
+<span class="tag">&lt;/Invoice&gt;</span></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Mandatory note when scheme 0231 is used</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>Electronic address remains the seller&#8217;s own endpoint, never the single taxable person SIREN</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>Seller&#8217;s own SIRET with schemeID 0009</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>SIREN of the single taxable person with schemeID 0231, one occurrence, 9 digits</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="5"></i><b>5</b></td>
+<td>Seller&#8217;s own SIREN (BT-30) with schemeID 0002</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="6"></i><b>6</b></td>
+<td>Single taxable person name, postal address and VAT number (BT-63) in BG-11</td>
+</tr>
+</table>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+Reference examples are available under <code>examples/country-specific-examples/france/</code>: <code>PUF_France_UC29_SingleVATEntity_Invoice.xml</code>, <code>PUF_France_UC29_SingleVATEntity_CreditNote.xml</code>, and <code>PUF_France_B2G_UC29_SingleVATEntity_Invoice.xml</code>.
+</td>
+</tr>
+</table>
 </div>
 </div>
 </div>

--- a/specification/country-specifics/france.adoc
+++ b/specification/country-specifics/france.adoc
@@ -70,6 +70,8 @@ France requires specific information to be provided in invoice notes using stand
 
 Each text code must be provided in a separate `cbc:Note` element with the format: `#CODE#value`
 
+NOTE: `cbc:Note` is typed as `NoteType`, which extends a bare text type and has no note-code component. The subject code is therefore not carried as a code of its own, and the `#CODE#` prefix is a text convention inside the note text that neither the PUF schema nor PUF validation can check. The prefix is split into the subject code (BT-21) and the note text (BT-22) when the document is transformed to the French target format.
+
 ===== Available Text Codes
 
 [cols="1,2,3,2", options="header"]
@@ -148,8 +150,8 @@ Each text code must be provided in a separate `cbc:Note` element with the format
 
 |#TXD#
 |Single taxable person member
-|Mention of the member of a single taxable person
-|*Required:* `Membre d'un assujetti unique`
+|Mention that the seller is a member of a single taxable person (assujetti unique). Mandatory whenever the seller party carries identification scheme `0231`, see <<_single_taxable_person_identification_assujetti_unique, Single Taxable Person Identification>>.
+|*Required:* `MEMBRE_ASSUJETTI_UNIQUE`
 |===
 
 IMPORTANT:
@@ -159,6 +161,8 @@ IMPORTANT:
 * #BAR# is not required for B2G. B2G examples use `#ADN#B2G` and should provide `puf:ComplianceActivatedIndicator` = `true`
 * Only ONE #BAR# note is allowed per invoice
 * `#REG#` can be used for seller registration data such as share capital and other regulatory company information
+* `#TXD#` must carry the literal value `MEMBRE_ASSUJETTI_UNIQUE`. The French phrase `Membre d'un assujetti unique` is the value BR-FR-MAP-06 and BR-FR-MAP-07 require in the downstream Flux 1 note text (BT-22) and Flux 10.1 report note (TT-27), and is never what a source document carries
+* The `#TXD#` note must be the last `cbc:Note` of the document, or the note that follows it must itself begin with a text code prefix. `BR-FR-CO-14` joins all document-level notes into one string with no separator and reads the value between the TXD prefix and the next hash character, so a following note without a text code prefix is absorbed into that value and the fatal rule fires
 
 ===== Implementation Example
 
@@ -186,7 +190,7 @@ IMPORTANT:
 ----
 <Invoice>
     <!-- Code omitted for clarity -->
-    <cbc:Note>#TXD#Membre d'un assujetti unique</cbc:Note>
+    <cbc:Note>#TXD#MEMBRE_ASSUJETTI_UNIQUE</cbc:Note>
     <cbc:Note>#BAR#B2B</cbc:Note>
     <!-- Code omitted for clarity -->
 </Invoice>
@@ -541,6 +545,78 @@ French VAT numbers should use the 'FR' prefix format:
     <!-- Code omitted for clarity -->
 </Invoice>
 ----
+
+===== Single Taxable Person Identification (Assujetti Unique)
+
+Identification scheme `0231` carries the SIREN of the single taxable person (assujetti unique) that the seller is a member of. It identifies a legal entity other than the seller, and it is valid only as a seller private identifier (BT-29):
+
+* Provide it on `cac:AccountingSupplierParty/cac:Party/cac:PartyIdentification/cbc:ID` with `@schemeID` `0231`. Scheme `0231` must never be used on the buyer, on any other party, or on `cac:PartyLegalEntity/cbc:CompanyID`.
+* Provide it exactly once. Only one identifier per scheme is allowed for a party (`BR-FR-CO-10`).
+* The value must be exactly 9 digits (`BR-FR-32`).
+* `0231` is an ISO 6523 ICD value and not a CEF EAS value, so it must never be used as an electronic address in `cbc:EndpointID` (BT-34 and BT-49), which would breach `BR-CL-25`.
+* The value must be the SIREN of a single taxable person registered in the PPF Annuaire (`BR-FR-CO-13`). This is a business rule verified by the PPF, with no Schematron implementation, and senders cannot pre-check it: the Annuaire data model has no representation of a single taxable person.
+* `cac:PartyLegalEntity/cbc:CompanyID` with scheme `0002` is unaffected and remains the seller's own SIREN (BT-30).
+
+Using scheme `0231` obliges the sender to provide two further elements in the same document:
+
+* The note `#TXD#MEMBRE_ASSUJETTI_UNIQUE` (`BR-FR-CO-14`), see <<_french_text_codes_note_elements, French Text Codes>>. Place it as the last `cbc:Note` of the document, or immediately before another note that begins with a text code prefix. `BR-FR-CO-14` joins all document-level notes into one string with no separator and reads the value between the TXD prefix and the next hash character, so a following note without a text code prefix is absorbed into that value and the fatal rule fires.
+* A `cac:TaxRepresentativeParty` (BG-11) carrying the name, VAT number (BT-63) and postal address of the single taxable person (`BR-FR-CO-15`). The VAT for the invoice is declared by the single taxable person, not by the seller.
+
+*Example*
+[source,xml]
+----
+<Invoice>
+    <!-- Code omitted for clarity -->
+    <cbc:Note>#TXD#MEMBRE_ASSUJETTI_UNIQUE</cbc:Note><!--1-->
+    <!-- Code omitted for clarity -->
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cbc:EndpointID schemeID="0225">33344455566677</cbc:EndpointID><!--2-->
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="0009">33344455566677</cbc:ID><!--3-->
+            </cac:PartyIdentification>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="0231">888999000</cbc:ID><!--4-->
+            </cac:PartyIdentification>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Filiale Alpha SAS</cbc:RegistrationName>
+                <cbc:CompanyID schemeID="0002">333444555</cbc:CompanyID><!--5-->
+            </cac:PartyLegalEntity>
+            <!-- Code omitted for clarity -->
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <!-- Code omitted for clarity -->
+    <cac:TaxRepresentativeParty><!--6-->
+        <cac:PartyName>
+            <cbc:Name>Groupe Fiscal Innovatech</cbc:Name>
+        </cac:PartyName>
+        <cac:PostalAddress>
+            <cbc:StreetName>Tour Innovatech, 1 Parvis de la Défense</cbc:StreetName>
+            <cbc:CityName>Puteaux</cbc:CityName>
+            <cbc:PostalZone>92800</cbc:PostalZone>
+            <cac:Country>
+                <cbc:IdentificationCode>FR</cbc:IdentificationCode>
+            </cac:Country>
+        </cac:PostalAddress>
+        <cac:PartyTaxScheme>
+            <cbc:CompanyID>FR88888999000</cbc:CompanyID>
+            <cac:TaxScheme>
+                <cbc:ID>VAT</cbc:ID>
+            </cac:TaxScheme>
+        </cac:PartyTaxScheme>
+    </cac:TaxRepresentativeParty>
+    <!-- Code omitted for clarity -->
+</Invoice>
+----
+
+<1> Mandatory note when scheme 0231 is used
+<2> Electronic address remains the seller's own endpoint, never the single taxable person SIREN
+<3> Seller's own SIRET with schemeID 0009
+<4> SIREN of the single taxable person with schemeID 0231, one occurrence, 9 digits
+<5> Seller's own SIREN (BT-30) with schemeID 0002
+<6> Single taxable person name, postal address and VAT number (BT-63) in BG-11
+
+NOTE: Reference examples are available under `examples/country-specific-examples/france/`: `PUF_France_UC29_SingleVATEntity_Invoice.xml`, `PUF_France_UC29_SingleVATEntity_CreditNote.xml`, and `PUF_France_B2G_UC29_SingleVATEntity_Invoice.xml`.
 
 ==== Mandate Scenarios - Agent Parties
 

--- a/specification/syntax/document-level/Party.adoc
+++ b/specification/syntax/document-level/Party.adoc
@@ -36,7 +36,8 @@ Identifier of the party.
 |`cac:PartyIdentification/cbc:ID/@schemeID`
 |**Party Identifier Scheme** +
 Scheme identifier of party identifier. +
-Value must be according to code list https://pagero.github.io/puf-code-lists/#_puf_008_identificationscheme[PUF-008-IDENTIFICATIONSCHEME^].
+Value must be according to code list https://pagero.github.io/puf-code-lists/#_puf_008_identificationscheme[PUF-008-IDENTIFICATIONSCHEME^]. +
+For France, scheme `0231` on `cac:AccountingSupplierParty/cac:Party/cac:PartyIdentification/cbc:ID` is the SIREN of the single taxable person (assujetti unique) that the seller is a member of. It is allowed on the seller only, exactly once, and must be exactly 9 digits. It is an ISO 6523 ICD value and not a CEF EAS value, so it must never be used as an electronic address in `cbc:EndpointID`. `cac:PartyLegalEntity/cbc:CompanyID` with scheme `0002` remains the seller's own SIREN. Using `0231` also obliges the sender to provide the note `#TXD#MEMBRE_ASSUJETTI_UNIQUE` and a `cac:TaxRepresentativeParty` carrying the name, VAT number and postal address of the single taxable person.
 
 |`cac:PartyName/cbc:Name`
 |**Party name** +


### PR DESCRIPTION
The documented `#TXD#` value fails BR-FR-CO-14, which is fatal in FR Flux 2 1.4.0. Corrected to `MEMBRE_ASSUJETTI_UNIQUE`, documented scheme 0231 and its dependent obligations, and added the missing CreditNote example.

Tests: XSD sweep and compiled PUF Schematron pass; publication rebuilt.
